### PR TITLE
disable the bastion host after migrations run successful

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,14 @@ jobs:
           export DJANGO_SUPERUSER_PASSWORD=$SUPERUSER_PASSWORD
           make resetadminpassword
 
+      - name: Turn off Bastion Host
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          cd infra
+          ./disable-bastion-host.sh
+
       - name: Manually Deploy ECS Task (Post-Migration)
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -168,3 +168,12 @@ The domains are setup using Route53.  It's good to know that there is a service 
 Note: Jim or someone on the tax court is responsible for adding those NS records manually to their aws account.  See the diagram below for more details.
 
 ![./docs/diagrams/route53-setup.png](./docs/diagrams/route53-setup.png)
+
+
+## Updating the Deployer Policy
+
+The deployer policy is setup in the aws account using the `update_aws_policy.sh` script.  This script will get the aws account id and use that to update the policy in the aws account.  It will also update the policy in the `deployer-policy.json` file.
+
+```shell
+./update_aws_policy.sh
+```

--- a/infra/disable-bastion-host.sh
+++ b/infra/disable-bastion-host.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+AWS_DEFAULT_REGION="us-east-1"
+export AWS_DEFAULT_REGION
+
+
+source ./helpers.sh
+
+required_env_vars=(
+  "ENVIRONMENT"
+)
+check_env_vars "${required_env_vars[@]}"
+
+# look up the bastion host by name "${var.environment}-bastion-host"
+INSTANCE_ID=$(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=${ENVIRONMENT}-bastion-host" \
+    --query "Reservations[*].Instances[*].InstanceId" \
+    --output text)
+
+if [ -z "$INSTANCE_ID" ]; then
+    echo "No bastion host found with name ${ENVIRONMENT}-bastion-host"
+    exit 1
+fi
+
+aws ec2 stop-instances --instance-ids $INSTANCE_ID

--- a/infra/update_aws_policy.sh
+++ b/infra/update_aws_policy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Verify script is run from infra directory
+if [[ $(basename "$PWD") != "infra" ]]; then
+    echo "Error: This script must be run from the infra directory"
+    exit 1
+fi
+
+
+# Get AWS Account ID
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+POLICY_ARN="arn:aws:iam::${AWS_ACCOUNT_ID}:policy/deployer-policy"
+POLICY_FILE="./iam/deployer-policy.json"
+
+# Check if policy file exists
+if [ ! -f "$POLICY_FILE" ]; then
+    echo "Error: Policy file not found at $POLICY_FILE"
+    exit 1
+fi
+
+# Create new policy version and set as default
+aws iam create-policy-version \
+    --policy-arn "$POLICY_ARN" \
+    --policy-document "file://$POLICY_FILE" \
+    --set-as-default
+
+if [ $? -eq 0 ]; then
+    echo "Successfully updated policy $POLICY_ARN"
+else
+    echo "Failed to update policy"
+    exit 1
+fi


### PR DESCRIPTION
## Update Policy Script

Often when adding new features, we need to update the iam policy so that the ci/cd pipeline has access to create new aws resources.  The script is called `infra/update_aws_policy.sh` and you can manually run it from inside the infra directory if you change the .json file and want to apply those changes to your env.

## Disable Bastion Script

There is a new script hooked into the ci/cd pipeline which will turn off the bastion after migration scripts run.  This will reduce costs and also increase security (no need to have a potential point of access into the system running unless we need it).  The bastion will get restarted when terraform runs.