### PR TITLE
Add Ruff as pre-req to use make commands to run project in ReadMe file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ cd website
 pyenv install
 ```
 
+#### Setup Ruff
+
+```
+brew install ruff
+```
+
 #### Setup Pre-Commit
 
 Before you commit to the repo, we run some checks to verify and fix the formatting of python.


### PR DESCRIPTION
We ran into issues with the make commands this morning, so updated the ReadMe to include the missing step to get it going. 