### PR TITLE
Make search_description (AKA Meta Description) required in admin screen

### DIFF
--- a/website/home/models.py
+++ b/website/home/models.py
@@ -14,6 +14,7 @@ from wagtail.contrib.settings.models import (
 
 Page._meta.get_field("search_description").blank = False
 
+
 @register_setting
 class Footer(BaseGenericSetting):
     technicalQuestions = RichTextField(


### PR DESCRIPTION
The meta description is already included in the base page if present. All we need to do to make it universal is update the Page model to make the field required in the admin screen. 

Validation Error saving a page with no meta description:
![image](https://github.com/user-attachments/assets/c2341995-ee71-47b3-8f23-3488d3edb938)

HTML element with meta description once entered and saved: 
![image](https://github.com/user-attachments/assets/db632e8b-5925-4c46-8fdd-5806c468d8fa)

For reference, the required HTML code for meta page descriptions: 
![image](https://github.com/user-attachments/assets/062e0c6a-2c5d-4ac1-998f-da20c80337b2)
