### PR TITLE
correct settings for dev

### DIFF
--- a/website/app/settings/dev.py
+++ b/website/app/settings/dev.py
@@ -28,3 +28,4 @@ SESSION_COOKIE_SECURE = True
 
 DEBUG = True
 BASE_URL = f'https://{os.getenv("DOMAIN_NAME")}'
+ENVIRONMENT = "dev"


### PR DESCRIPTION
The `ENVIRONMENT` settings int `dev.py` is overwritten when you import `local.py` after.

## Issue Caused

Post #76 change, the environment value is stored in Django conf settings. Looks like that value is over written for `dev` when the merge and deployment happened.

In the below `create_users` command, the Github environment was correctly identified as `dev`. However, when the `dev.py` settings applied, Django configuration for `ENVIRONMENT` setting got overwritten to `local`. This caused the `create_users` command to behave that it is running locally and created the secrets locally. Note messages `"created new secret locally."`.

See [https://github.com/ustaxcourt/website-wagtail/actions/runs/13188036636](https://github.com/ustaxcourt/website-wagtail/actions/runs/13188036636/job/36814764791#step:11:161)

Editor user:
```sh
. ~/.venv/website-wagtail/bin/activate && DJANGO_SETTINGS_MODULE=${settings:-app.settings.local} python manage.py create_users --group_name ${group:-"Editors"}
Secret 'WAGTAIL_EDITOR_PASSWORD' not found in 'website_secrets'; created new secret locally.
Editor password successfully changed and added to 'Editors' group.'
```

Moderator user:
```sh
. ~/.venv/website-wagtail/bin/activate && DJANGO_SETTINGS_MODULE=${settings:-app.settings.local} python manage.py create_users --group_name ${group:-"Editors"}
Secret 'WAGTAIL_MODERATOR_PASSWORD' not found in 'website_secrets'; created new secret locally.
Moderator password successfully changed and added to 'Moderators' group.'
```

## Fix

Redefine the `ENVIRONMENT` value after the import from local is done.