### PR TITLE
Exclude JSON unsafe chars in auto generated website secrets

### DIFF
--- a/website/home/utils/secrets.py
+++ b/website/home/utils/secrets.py
@@ -33,7 +33,7 @@ def write_local_secrets(data, filename="website_secrets"):
 
 
 def generate_random_password(length=16):
-    characters = string.ascii_letters + string.digits + string.punctuation
+    characters = string.ascii_letters + string.digits + "+-_/:;.,()[]<>?!"
     return "".join(secrets.choice(characters) for _ in range(length))
 
 


### PR DESCRIPTION
We need to exclude some special punctuation chars from the password generation. Punctuations like `"` or `$` will mess up the JSON parsing, environment setup routine, and need to be excluded from password generation.

This change uses only a set of safe punctuations that should not error JSON parsing.

