### PR TITLE
s3 storages to be considered as internal

### DIFF
--- a/website/app/templates/base.html
+++ b/website/app/templates/base.html
@@ -132,18 +132,14 @@
 
           if (isSubdomain(href)) {
             window.open(href, "_blank");
-          } else{
-
+          } else {
             let newTab = window.open("/redirect/", "_blank");
-
             if (newTab) {
               newTab.sessionStorage.setItem("redirect_url", href);
             } else{
               alert("Pop-up blocked!  Please allow pop-ups for this site.");
-
             }
           }
-
 
         });
       });


### PR DESCRIPTION
### Consider S3 storage as same domain

Stop showing redirect alert on PDFs stored in internal s3 storages.

### Testing

Deployed in Sandbox: https://sappachi-sandbox-web.ustaxcourt.gov/case_related_forms/

- Linking PDFs in "sappachi-sandbox-ustc-website-assets.s3.amazonaws.com/*" opens the link in new tab.
- Shows no redirect warning.
- Other internal / external links behavior not changed and should act as expected.