### PR TITLE
Update content panel to include only navigation ribbon and body fields

### DIFF
--- a/website/home/models.py
+++ b/website/home/models.py
@@ -341,9 +341,6 @@ class EnhancedStandardPage(NavigationMixin, Page):
     )
     content_panels = Page.content_panels + [
         FieldPanel("navigation_ribbon"),
-        FieldPanel("title_text"),
-        FieldPanel("description"),
-        FieldPanel("video_url"),
         FieldPanel("body"),
     ]
 


### PR DESCRIPTION
Moved the YouTube video link to the inner menu and displaying only the navigation ribbon and body on the content panel in Wagtail.