### PR TITLE
Bug/Style update for the navigation ribbon in mobile view.

### DIFF
--- a/website/app/static/css/app.css
+++ b/website/app/static/css/app.css
@@ -214,3 +214,23 @@ button.link:hover {
         font-size: 2.5rem;
     }
 }
+@media (min-width: 320px) and (max-width: 768px) {
+    .blue-page-links-bar {
+        gap: 5px;
+        border-radius: 3px;
+    }
+
+    .blue-page-links-bar a .title {
+        display: none !important;
+    }
+
+    .blue-page-links-bar a {
+        gap: 5px;
+        font-size: 0.8rem;
+        padding: 12px 6px;
+    }
+
+    .blue-page-links-bar .ti {
+        font-size: 20px;
+    }
+}

--- a/website/home/templates/home/enhanced_standard_page.html
+++ b/website/home/templates/home/enhanced_standard_page.html
@@ -322,7 +322,7 @@
                 {% for link in page.navigation_ribbon.links.all %}
                     <a href="{{ link.url }}" aria-label="{{ link.title }}">
                         <i class="{{ link.icon }}" aria-hidden="true"></i>
-                        <div class="title">{{ link.title }}</div>
+                        <div class="title" style="display: block;">{{ link.title }}</div>
                     </a>
                 {% endfor %}
             </div>


### PR DESCRIPTION
• In mobile view, only the icons are displayed in the navigation ribbon.
• Page titles are hidden.


<img width="358" alt="Screenshot 2025-03-17 at 5 32 32 PM" src="https://github.com/user-attachments/assets/449892ff-d53e-4705-8e95-9f12c26d39fc" />
<img width="375" alt="Screenshot 2025-03-17 at 5 29 44 PM" src="https://github.com/user-attachments/assets/3522313d-be7b-4213-837a-46bf710cc6a1" />
<img width="391" alt="Screenshot 2025-03-17 at 5 29 11 PM" src="https://github.com/user-attachments/assets/d53074fe-789b-49b6-822f-d96264a3cfd7" />
