### PR TITLE
adding back arguments to prevent error

### DIFF
--- a/website/app/settings/base.py
+++ b/website/app/settings/base.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.sitemaps",
     "django.contrib.staticfiles",
     "fontawesomefree",
 ]

--- a/website/app/templates/previews/header_preview.html
+++ b/website/app/templates/previews/header_preview.html
@@ -31,7 +31,7 @@
         <link href="https://fonts.googleapis.com/css?family=Source Sans Pro:400,700,"
               rel="stylesheet" />
     </head>
-    <body class="{% block body_class %}  {% endblock %}">
+    <body class="{% block body_class %} {% endblock %}">
         {% include 'header.html' %}
         <script type="text/javascript" src="{% static 'js/app.js' %}"></script>
     </body>

--- a/website/app/urls.py
+++ b/website/app/urls.py
@@ -1,17 +1,17 @@
 from django.conf import settings
 from django.urls import include, path
 from django.contrib import admin
-
+from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [
+    path("sitemap.xml", sitemap),
     path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
 ]
-
 
 if settings.DEBUG:
     from django.conf.urls.static import static

--- a/website/home/models.py
+++ b/website/home/models.py
@@ -816,7 +816,7 @@ class NavigationMenu(
         blank=True,
     )
 
-    def get_preview_template(self):
+    def get_preview_template(self, request, mode_name):
         return "previews/header_preview.html"
 
     def get_preview_context(self, request, mode_name):


### PR DESCRIPTION
<img width="575" alt="Screenshot 2025-03-27 at 3 50 16 PM" src="https://github.com/user-attachments/assets/224bec17-1154-421c-a240-06dd4300598a" />

removing those unused function arguments crashes the app