### PR TITLE
Feature/add redirects to all documents in the legacy site 8908184391

### DIFF
--- a/website/app/urls.py
+++ b/website/app/urls.py
@@ -1,7 +1,6 @@
 import boto3
 from botocore.exceptions import ClientError
 from django.conf import settings
-from django.http import HttpResponseNotFound
 from django.urls import include, path
 from django.contrib import admin
 from wagtail.contrib.sitemaps.views import sitemap
@@ -18,7 +17,6 @@ def all_legacy_documents_redirect(request, filename):
         "s3",
         region_name="us-east-1",
     )
-
 
     # Construct the key
     prefix = "documents/"


### PR DESCRIPTION
Pull Request Overview (Thanks, Copilot!)
This PR adds redirection for legacy PDF documents by integrating S3 checks into the URL configuration.

- Introduces a new function to validate the existence of documents in S3 before redirecting.
- Updates URL patterns to route legacy document requests to the new redirection function.
- Integrates boto3 to interact with the S3 bucket for document verification.

Deployed examples:
Document not found: https://mmiest-moore-sandbox-web.ustaxcourt.gov/resources/something/010315.pdf
Document found: https://mmiest-moore-sandbox-web.ustaxcourt.gov/resources/something/010318.pdf
Confirm previous work with Tax Court Reports still works: https://mmiest-moore-sandbox-web.ustaxcourt.gov/resources/ropp/tc-reports/vol-060.pdf

None of the pages are new, just the handling of document lookups