### PR TITLE
Pass DJANGO environment settings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,4 +178,4 @@ jobs:
           ssh-keyscan -H ${BASTION_HOST_IP} > /tmp/known_hosts
           ssh -o UserKnownHostsFile=/tmp/known_hosts -L 5432:${DATABASE_HOSTNAME} -N -i ../.ssh/id_rsa ubuntu@${BASTION_HOST_IP} &
           export DATABASE_URL="postgresql://master:${DATABASE_PASSWORD}@localhost:5432/postgres"
-          make production-checks
+          make production-checks settings="app.settings.${ENVIRONMENT}"


### PR DESCRIPTION
## Change

- Pass the appropriate environment settings file to the `make production-checks` command. Without passing the right settings file, the command defaults to local for settings.