### PR TITLE
Fix DB Restore and migration with environment

### DIFF
--- a/.github/workflows/restore_rds.yml
+++ b/.github/workflows/restore_rds.yml
@@ -147,23 +147,17 @@ jobs:
           echo "Changing to website directory..."
           cd website || { echo "ERROR: Failed to cd into website directory"; exit 1; }
 
-          # Print variables being used for connection (useful for debugging)
-          echo "Using Bastion Host IP: ***" # Masked automatically by ::add-mask::
-          echo "Using Database Hostname: ***" # Masked automatically by ::add-mask::
-
           echo "Scanning bastion host key..."
           # Add host key to known_hosts
           ssh-keyscan -H ${BASTION_HOST_IP} >> ~/.ssh/known_hosts || { echo "ERROR: ssh-keyscan failed for ${BASTION_HOST_IP}"; exit 1; }
           echo "Host key scanned and added."
 
           echo "Starting SSH tunnel in background..."
-          # Use standard SSH key location; removed -vvv for cleaner logs
-          # Use -o StrictHostKeyChecking=yes now that key is scanned
           ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts \
               -L 5432:${DATABASE_HOSTNAME}:5432 \
               -f -N -i ~/.ssh/id_rsa ubuntu@${BASTION_HOST_IP} || { echo "ERROR: SSH tunnel command failed to start"; exit 1; }
           echo "SSH tunnel command executed. Waiting for tunnel establishment..."
-          sleep 5 # Give tunnel a moment
+          sleep 5
 
           echo "Exporting DATABASE_URL for local connection through tunnel..."
           # Masked password will be used here

--- a/.github/workflows/restore_rds.yml
+++ b/.github/workflows/restore_rds.yml
@@ -30,7 +30,7 @@ on:
           - 'Yes'
         default: 'Yes'
       apply_migration:
-        description: 'Apply Database Migrations after restore?'
+        description: 'Apply Database Migrations?'
         required: false
         type: choice
         options:

--- a/.github/workflows/restore_rds.yml
+++ b/.github/workflows/restore_rds.yml
@@ -21,6 +21,14 @@ on:
         description: 'RDS Snapshot ID to restore from'
         required: true
         type: string
+      create_backup_db:
+        description: 'Create backup DB?'
+        required: false
+        type: choice
+        options:
+          - 'No'
+          - 'Yes'
+        default: 'Yes'
       apply_migration:
         description: 'Apply Database Migrations after restore?'
         required: false
@@ -52,17 +60,47 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Run RDS Restore Script
+      - name: Set up Terraform
+        uses: ./.github/actions/setup-terraform
+
+      - name: Set up Python
+        uses: ./.github/actions/setup-python
+
+      - name: Setup Python Dependencies
+        run: |
+          cd website
+          make setup
+
+      - name: Update Bastion SG for Runner Access
+        id: tf_update_sg
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        shell: bash
+          AWS_REGION: us-east-1
         run: |
-          ./infra/restore-rds.sh \
-            "${{ github.event.inputs.source_instance_id }}" \
-            "${{ github.event.inputs.snapshot_id }}"
+          cd infra
+          # Source helper scripts to set TF variables (STATE_BUCKET, KEY, LOCK_TABLE, REGION etc.)
+          # Ensure these scripts correctly use the $ENVIRONMENT variable
+          echo "Setting up Terraform backend config for environment: ${ENVIRONMENT}"
+          source ./setup.sh
+          source ./setup_zone.sh
+          ./update-deployer-policy.sh # Consider if this is needed here
+          echo "Initializing Terraform..."
+          terraform init \
+              -upgrade \
+              -backend=true \
+              -backend-config=bucket="${STATE_BUCKET}" \
+              -backend-config=key="${KEY}" \
+              -backend-config=dynamodb_table="${LOCK_TABLE}" \
+              -backend-config=region="${REGION}"
+          echo "Refreshing Terraform state..."
+          terraform refresh
+          echo "Applying targeted update to Bastion Security Group..."
+          # Assuming bastion_sg is within a module named 'app'
+          terraform apply -target=module.app.aws_security_group.bastion_sg -auto-approve
+          echo "Bastion Security Group update applied."
 
-      - name: Set up SSH Key
+      - name: Load Secrets and Set up SSH Key
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -70,6 +108,7 @@ jobs:
           cd infra
           . ./load-secrets.sh
           cd ..
+          # Load necessary secrets into GitHub Actions environment for subsequent steps
           echo "DATABASE_PASSWORD=$DATABASE_PASSWORD" >> $GITHUB_ENV
           echo "::add-mask::${DATABASE_PASSWORD}"
           echo "DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD" >> $GITHUB_ENV
@@ -80,9 +119,24 @@ jobs:
           echo "::add-mask::${DATABASE_HOSTNAME}"
           echo "BASTION_HOST_IP=$BASTION_HOST_IP" >> $GITHUB_ENV
           echo "::add-mask::${BASTION_HOST_IP}"
-          mkdir -p .ssh
-          echo "${BASTION_PRIVATE_KEY}" | base64 --decode > .ssh/id_rsa
-          chmod 600 .ssh/id_rsa
+          # Create SSH key file
+          mkdir -p ~/.ssh # Use ~/.ssh for standard location
+          echo "${BASTION_PRIVATE_KEY}" | base64 --decode > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "SSH key configured."
+
+      - name: Run RDS Restore Script (Conditional)
+        if: github.event.inputs.create_backup_db == 'Yes'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        shell: bash
+        run: |
+          echo "Starting RDS restore process..."
+          ./infra/restore-rds.sh \
+            "${{ github.event.inputs.source_instance_id }}" \
+            "${{ github.event.inputs.snapshot_id }}"
+          echo "RDS restore script finished."
 
       - name: Run Migrations (Conditional)
         if: github.event.inputs.apply_migration == 'Yes'
@@ -90,12 +144,39 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          cd website
-          set -e
+          echo "Changing to website directory..."
+          cd website || { echo "ERROR: Failed to cd into website directory"; exit 1; }
 
-          ssh-keyscan -H ${BASTION_HOST_IP} > /tmp/known_hosts
-          ssh -o UserKnownHostsFile=/tmp/known_hosts -L 5432:${DATABASE_HOSTNAME} -N -i ../.ssh/id_rsa ubuntu@${BASTION_HOST_IP} &
+          # Print variables being used for connection (useful for debugging)
+          echo "Using Bastion Host IP: ***" # Masked automatically by ::add-mask::
+          echo "Using Database Hostname: ***" # Masked automatically by ::add-mask::
+
+          echo "Scanning bastion host key..."
+          # Add host key to known_hosts
+          ssh-keyscan -H ${BASTION_HOST_IP} >> ~/.ssh/known_hosts || { echo "ERROR: ssh-keyscan failed for ${BASTION_HOST_IP}"; exit 1; }
+          echo "Host key scanned and added."
+
+          echo "Starting SSH tunnel in background..."
+          # Use standard SSH key location; removed -vvv for cleaner logs
+          # Use -o StrictHostKeyChecking=yes now that key is scanned
+          ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts \
+              -L 5432:${DATABASE_HOSTNAME}:5432 \
+              -f -N -i ~/.ssh/id_rsa ubuntu@${BASTION_HOST_IP} || { echo "ERROR: SSH tunnel command failed to start"; exit 1; }
+          echo "SSH tunnel command executed. Waiting for tunnel establishment..."
+          sleep 5 # Give tunnel a moment
+
+          echo "Exporting DATABASE_URL for local connection through tunnel..."
+          # Masked password will be used here
           export DATABASE_URL="postgresql://master:${DATABASE_PASSWORD}@localhost:5432/postgres"
-          echo "Running migrations..."
-          make migrate
-          make createpages settings="app.settings.${ENVIRONMENT}"
+          echo "DATABASE_URL exported."
+
+          echo "Running database migrations (make migrate)..."
+          make migrate || { echo "ERROR: 'make migrate' failed"; exit 1; }
+          echo "'make migrate' completed."
+
+          echo "Running custom commands (make createpages)..."
+          # Ensure settings argument format is correct for your Makefile/manage.py
+          make createpages settings="app.settings.${ENVIRONMENT}" || { echo "ERROR: 'make createpages' failed"; exit 1; }
+          echo "'make createpages' completed."
+
+          echo "Migration step finished successfully."

--- a/.github/workflows/restore_rds.yml
+++ b/.github/workflows/restore_rds.yml
@@ -72,6 +72,7 @@ jobs:
           make setup
 
       - name: Update Bastion SG for Runner Access
+        if: github.event.inputs.apply_migration == 'Yes'
         id: tf_update_sg
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ aws-init: check-env
 
 create-db-restore:
 	@echo "Creating database restore for environment: $(env)"
-	@cd infra && ./restore-rds.sh $(db_instance_id) $(db_snapshot_id)
+	@cd infra && ENVIRONMENT=$(env) ./restore-rds.sh $(db_instance_id) $(db_snapshot_id)
 
 start-tunnel:
 	@echo "Starting SSH tunnel to bastion host..."

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the code for [ustaxcourt.gov](https://ustaxcourt.gov). 
 
 Note, we plan to get sub domains for these environments, and these links are subject to change for now.
 
-# Running the Wagtail Website
+## Running the Wagtail Website
 
 There are a number of make commands to run the service locally. See Makefile for more details. To simply run the app, run the following commands in your terminal from the website-wagtail directory:
 
@@ -41,18 +41,16 @@ brew install node
 brew install nvm
 ```
 
-#### Setup Tfenv
+#### Setup `tfenv`
 
-You will want to install tfenv so that you can install and switch to different terraform versions.
+You will want to install `tfenv` so that you can install and switch to different terraform versions. The current terraform version is tracked in file [.terraform-version](./.terraform-version).
 
 ```shell
 brew install tfenv
-tfenv install 1.10.4
-tfenv use 1.10.4
+tfenv install
 ```
 
-
-#### Setup Pre-Commit
+#### Setup `pre-commit`
 
 Before you commit to the repo, we run some checks to verify and fix the formatting of python.
 
@@ -101,7 +99,7 @@ make resetadminpassword
 
 ### Run
 
-Finally, running applicaiton.
+Finally, running application.
 
 ```shell
 make run
@@ -119,7 +117,7 @@ See `make superuser` to see how it is setup first time.
 
 Mike will reach out to you with a aws console username & password. Please verify you can login with it, and also reach out to have your default password changed because you can't do it in the console from what we've seen.
 
-Next, you'll want to make sure your application is setup with your sso. You should be able to run this command and enter your SSO url when prompted. You'll also be promted with some other stuff you want to fill in.
+Next, you'll want to make sure your application is setup with your sso. You should be able to run this command and enter your SSO url when prompted. You'll also be prompted with some other stuff you want to fill in.
 
 - `aws sso configure`
 
@@ -168,7 +166,7 @@ If you run a terraform init with your sandbox account, but then try to run it ag
 Leaving your sandbox running without being used will waste money.  Remember to clean it up with the following steps:
 
 1. `cd infra`
-2. manually dissable delete protection for your rds database in file [rds.tf](./infra/modules/app/rds.tf)
+2. manually disable delete protection for your rds database in file [rds.tf](./infra/modules/app/rds.tf)
 3. modify `rds.tf` to remove the lifecycle rule preventing the destruction of the rds instance by setting `deletion_protection = false`
 4. `ENVIRONMENT=<SANDBOX ENV> ./destroy.sh` or run `make destroy`
   - Alternatively, you can use `make tag tag=sandbox-destroy`
@@ -180,6 +178,14 @@ If you want to connect to the database from your local machine, you will need to
 
 Because the RDS instance is behind a VPS, that means you will need to setup an SSH tunnel through a bastion host to be able to access it.
 
+Run the following `make` command.
+
+```bash
+make start-tunnel
+```
+
+Or
+
 `ssh -L 5432:<RDS_HOSTNAME>:5432 -N -i .ssh/id_rsa ubuntu@<IP_ADDRESS>`
 
 after running this in a separate terminal, you should be able to run migrations or connect directly using tableplus.
@@ -190,7 +196,7 @@ Remember to remove your IP address from the security group when done.
 
 Our code is currently deployed using github actions when your pull request is merged to the `development` branch.  The way this works, is the github action will spin up an ubuntu machine, pull in the branch code, setup python and terraform, and eventually it'll run terraform which will build the wagtail container, and deploy that container to aws ecs.  After updating our infrastructure, the ci/cd pipeline will run migration scripts via the bastion host tunnel which will update the ecs service with the latest wagtail migration scripts.  Finally, the github action workflow will update the ECS task to run with the latest version of the wagtail container.
 
-The application is publically accessible via an AWS ALB which points to ECS.
+The application is publicly accessible via an AWS ALB which points to ECS.
 
 ![./docs/diagrams/ci-cd.png](./docs/diagrams/ci-cd.png)
 
@@ -218,7 +224,7 @@ This document clarifies the process a developer should follow when assigned to a
 ## Summary
 
 Generally speaking, this project will follow a [feature-branch workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow):
--  `main` branch represents the official project history, and the starting point for all story work
+- `main` branch represents the official project history, and the starting point for all story work
 - developers work on stories by branching off of `main`, implementing their work in a feature branch, and ultimately integrating their feature branch back into `main` once their work is complete
 
 Additionally, we will use tags to facilitate deployment to production and sandbox instances.
@@ -269,7 +275,7 @@ Monitor the deployment under [Actions > Deploy](https://github.com/ustaxcourt/we
 
 9. **Open the `DOMAIN_NAME`** in your browser to verify that the website is functioning correctly.
 
-10. **Destroy application environment**. Verify you are able to destory the application environment by running destory command.
+10. **Destroy application environment**. Verify you are able to destroy the application environment by running destroy command.
 
 > [!WARNING]
 > Leaving your sandbox application environment running might incur unwanted expense. Once the testing is done, you should destroy the AWS resources.
@@ -286,7 +292,7 @@ make tag tag=sandbox-destroy
       - `fix`: code that fixes a bug or adds/clarifies documentation, e.g. `fix/broken-dropdown-1234`
       - `feature`: code that adds or enhances functionality of the app, e.g. `feature/new-disco-theme-1234`
     - `brief-description`: a few words to describe the purpose of the branch
-    - `monday-id`: the valu of the **Item ID** in Monday.com
+    - `monday-id`: the value of the **Item ID** in Monday.com
 3. Develop and test locally
 4. When ready for review, push branch to github (if not done already) and create a draft PR to `main`
 5. Deploy your feature to your sandbox by tagging your feature branch with `sandbox` , e.g.
@@ -301,7 +307,7 @@ Or, the following equivalent command.
 > Additionally, you can add/reassign tags using the Github website.
 
 6. Developer notifies team that feature is ready for review:
-  - by moving the story card in Monday.com to the `Watiting for review` lane, and
+  - by moving the story card in Monday.com to the `Waiting for review` lane, and
   - by notifying the stakeholders (UX, PO) in Teams that the feature is ready for testing.
 7. UX verifies AC in sandbox
 8. PO verifies AC in sandbox
@@ -310,5 +316,10 @@ Or, the following equivalent command.
 10. Once everything looks good (PR reviewed, UX+PO approval), merge the PR (thus integrating the feature into `main`)
 11. Once merged, a github automation will deploy the current state of `main` to the staging environment.
 
-## Troubleshooting Python/Python 3
-  - if make commands are not running try doing the command "which python3"  which should give you a path which can be inserted into the "path" portion of the following command to alias python with python3. (sudo ln -s "path" /usr/local/bin/python)
+### Troubleshooting Python/Python 3
+
+- If `make` commands are not running try doing the command "`which python3`"  which should give you a path which can be inserted into the "path" portion of the following command to alias python with python3. (`sudo ln -s "path" /usr/local/bin/python`)
+
+## Support Documents
+
+- To restore RDS database, follow instructions in [RDS-restore-steps.md](./docs/support/RDS-restore-steps.md).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ brew install nvm
 
 #### Setup `tfenv`
 
-You will want to install `tfenv` so that you can install and switch to different terraform versions. The current terraform version is tracked in file [.terraform-version](./.terraform-version).
+You will want to install `tfenv` so that you can install and switch to different terraform versions. The current terraform version used in this project is tracked in file [.terraform-version](./.terraform-version). `tfenv install` command installs the version mentioned in that file.
 
 ```shell
 brew install tfenv

--- a/docs/support/RDS-restore-steps.md
+++ b/docs/support/RDS-restore-steps.md
@@ -1,0 +1,220 @@
+# Workflow Documentation: Manual RDS Restore from Snapshot
+
+## Overview
+
+This GitHub Actions workflow provides a manual mechanism to restore an AWS Relational Database Service (RDS) instance from a specified snapshot. It is designed to be triggered manually via the GitHub Actions UI (`workflow_dispatch`). The workflow handles AWS authentication, infrastructure updates (specifically bastion host access), the core RDS restore operation (conditionally), and database migrations (conditionally) via an SSH tunnel through a bastion host.
+
+**Purpose:** To enable controlled database restores for environments like sandbox, development, or production from known snapshots, potentially followed by database schema migrations.
+
+**Technology Stack:**
+* GitHub Actions
+* AWS CLI / SDK (implicitly via `aws-actions/configure-aws-credentials` and scripts)
+* Terraform (for infrastructure adjustments)
+* Python/Django (for database migrations via `make`)
+* Bash (for orchestration scripts like `restore-rds.sh`, `load-secrets.sh`)
+* SSH (for tunneling to the database via bastion)
+
+## Trigger
+
+* **Type:** Manual (`workflow_dispatch`)
+* **How to trigger:** Navigate to the Actions tab in the GitHub repository, select "Manual RDS Restore from Snapshot" from the workflow list, and click "Run workflow". You will be prompted to provide the necessary inputs.
+
+## Inputs
+
+The workflow requires the following inputs when triggered manually:
+
+| Parameter            | Description                                 | Type    | Required | Options                    | Default   |
+| :------------------- | :------------------------------------------ | :------ | :------- | :------------------------- | :-------- |
+| `environment`        | Target AWS environment for the restore.     | `choice`  | Yes      | `sandbox`, `dev`, `production` | `sandbox` |
+| `source_instance_id` | The identifier of the original RDS instance from which the snapshot was taken. | `string`  | Yes      | N/A                        | N/A       |
+| `snapshot_id`        | The specific RDS snapshot identifier to restore from. | `string`  | Yes      | N/A                        | N/A       |
+| `create_backup_db`   | Choose 'Yes' to execute the RDS restore script. Select 'No' to skip the actual restore step (e.g., only run migrations on an existing DB). | `choice`  | No       | `No`, `Yes`                | `Yes`     |
+| `apply_migration`    | Choose 'Yes' to apply database migrations after the restore (if performed). Select 'No' to skip migrations. | `choice`  | No       | `No`, `Yes`                | `No`      |
+
+## Required Secrets
+
+The workflow relies on the following GitHub Actions secrets:
+
+| Secret Name             | Description                                                                 | Scope       |
+| :---------------------- | :-------------------------------------------------------------------------- | :---------- |
+| `AWS_ACCESS_KEY_ID`     | AWS Access Key ID for authentication. Must have sufficient IAM permissions. | Environment |
+| `AWS_SECRET_ACCESS_KEY` | AWS Secret Access Key associated with the Access Key ID.                    | Environment |
+
+**Note:** Additional sensitive information like `DATABASE_PASSWORD`, `DJANGO_SUPERUSER_PASSWORD`, `SECRET_KEY`, `DATABASE_HOSTNAME`, `BASTION_HOST_IP`, and `BASTION_PRIVATE_KEY` are expected to be fetched dynamically during the workflow execution by the `infra/load-secrets.sh` script, likely from AWS Secrets Manager or Parameter Store based on the selected `environment`.
+
+## Workflow Environment Configuration
+
+The workflow dynamically sets the GitHub Actions `environment` based on the `environment` input:
+
+* If input `environment` is `sandbox`, the GitHub environment `{triggering_actor}_sandbox` is used (e.g., `username_sandbox`).
+
+This allows for environment-specific secrets and protection rules within GitHub.
+
+## Workflow Steps
+
+Here's a breakdown of each step in the `rds-restore` job:
+
+---
+
+**1. Checkout code**
+* **Action:** `actions/checkout@v4`
+* **Description:** Checks out the repository code onto the GitHub Actions runner, making local scripts and configuration available.
+* **Inputs/Environment:** None.
+* **Expected Outcome:** Repository code is present in the runner's workspace.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* Network issues cloning the repository.
+        * *Troubleshooting:* Retry the workflow. Check GitHub status.
+    * *Error:* Insufficient permissions to access the repository (if it's private and runner doesn't have access).
+        * *Troubleshooting:* Ensure the Action has `contents: read` permission (as configured). Check repository access settings.
+
+---
+
+**2. Set Environment Variable**
+* **Command:** `echo "ENVIRONMENT=${{ github.event.inputs.environment }}" >> $GITHUB_ENV`
+* **Description:** Sets an environment variable `ENVIRONMENT` within the runner based on the user's `environment` input. This is used by subsequent scripts (e.g., `setup.sh`, `load-secrets.sh`).
+* **Inputs/Environment:** `github.event.inputs.environment`.
+* **Expected Outcome:** The `$ENVIRONMENT` variable is available for later steps.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* Unlikely, unless there's a fundamental issue with the runner environment or `$GITHUB_ENV` file.
+        * *Troubleshooting:* Verify runner health. Check workflow syntax.
+
+---
+
+**3. Configure AWS Credentials**
+* **Action:** `aws-actions/configure-aws-credentials@v4`
+* **Description:** Configures AWS credentials using the provided GitHub secrets (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) for the `us-east-1` region. Allows subsequent steps to interact with AWS services.
+* **Inputs/Environment:** `secrets.AWS_ACCESS_KEY_ID`, `secrets.AWS_SECRET_ACCESS_KEY`.
+* **Expected Outcome:** AWS CLI and SDKs are configured with valid credentials.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* Invalid credentials (wrong keys, expired keys).
+        * *Troubleshooting:* Verify the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets are correct and active in the GitHub environment settings.
+    * *Error:* IAM user/role associated with the keys lacks necessary permissions for subsequent AWS actions (RDS, EC2 SG updates, Secrets Manager/Parameter Store access).
+        * *Troubleshooting:* Review and update the IAM policy attached to the credentials to include required permissions (e.g., `rds:RestoreDBInstanceFromDBSnapshot`, `ec2:AuthorizeSecurityGroupIngress`, `ec2:RevokeSecurityGroupIngress`, `secretsmanager:GetSecretValue`, etc.).
+
+---
+
+**4. Set up Terraform**
+* **Action:** `./.github/actions/setup-terraform` (Local composite action)
+* **Description:** Executes a local composite action to set up the Terraform environment on the runner. The exact steps are defined within that action's definition file (`./.github/actions/setup-terraform/action.yml`). Typically involves installing Terraform CLI.
+* **Inputs/Environment:** None directly to this step, but subsequent Terraform steps depend on AWS credentials and `$ENVIRONMENT`.
+* **Expected Outcome:** Terraform CLI is installed and ready for use.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* Composite action file not found or has syntax errors.
+        * *Troubleshooting:* Verify the path `./.github/actions/setup-terraform` is correct and the `action.yml` file exists and is valid.
+    * *Error:* Failures during Terraform installation (e.g., network issues downloading).
+        * *Troubleshooting:* Check the composite action's script logs. Retry the workflow.
+
+---
+
+**5. Set up Python**
+* **Action:** `./.github/actions/setup-python` (Local composite action)
+* **Description:** Executes a local composite action to set up the Python environment. Likely involves installing a specific Python version.
+* **Inputs/Environment:** None directly.
+* **Expected Outcome:** Python interpreter is available.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* Composite action file not found or has syntax errors.
+        * *Troubleshooting:* Verify path and `action.yml` validity.
+    * *Error:* Failures during Python setup (network issues, incompatible runner OS).
+        * *Troubleshooting:* Check the composite action's script logs.
+
+---
+
+**6. Setup Python Dependencies**
+* **Commands:** `cd website`, `make setup`
+* **Description:** Changes into the `website` directory and runs `make setup`. This command is expected to install Python packages required for the Django application, typically using `pip` and a `requirements.txt` file defined within the Makefile target.
+* **Inputs/Environment:** Requires Python to be set up. Depends on the contents of `website/Makefile`.
+* **Expected Outcome:** All Python dependencies listed in `website/requirements.txt` (or equivalent) are installed.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* `website` directory not found.
+        * *Troubleshooting:* Ensure `actions/checkout` ran successfully and the directory structure is correct.
+    * *Error:* `make` command not found.
+        * *Troubleshooting:* Ensure `make` is installed on the `ubuntu-latest` runner (it usually is) or add an installation step.
+    * *Error:* `make setup` target fails (e.g., `pip install` errors due to network issues, package conflicts, missing system libraries).
+        * *Troubleshooting:* Check the output logs for specific `pip` errors. Update `requirements.txt` or the runner environment if system dependencies are missing. Examine the `website/Makefile`.
+
+---
+
+**7. Update Bastion SG for Runner Access**
+* **Commands:** `cd infra`, `source ./setup.sh`, `source ./setup_zone.sh`, `./update-deployer-policy.sh`, `terraform init ...`, `terraform refresh`, `terraform apply -target=module.app.aws_security_group.bastion_sg ...`
+* **Description:** This crucial step prepares for SSH access. It navigates to the `infra` directory, configures Terraform backend using environment-specific settings (via `setup.sh`, `setup_zone.sh`), potentially updates an IAM policy (`update-deployer-policy.sh`), initializes Terraform, refreshes state, and then applies a targeted change ONLY to the bastion host's security group (`module.app.aws_security_group.bastion_sg`). This modification likely adds a rule to allow SSH traffic from the GitHub Actions runner's current IP address.
+* **Inputs/Environment:** AWS Credentials, `$ENVIRONMENT`, Terraform state in S3/DynamoDB, local Terraform code (`infra/`), scripts (`setup.sh`, `setup_zone.sh`, `update-deployer-policy.sh`).
+* **Expected Outcome:** The bastion host's security group (`aws_security_group.bastion_sg` within `module.app`) is updated to allow SSH connections from the runner.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* Script failures (`setup.sh`, `setup_zone.sh`, `update-deployer-policy.sh`).
+        * *Troubleshooting:* Check the logic and execution permissions of these scripts. Ensure they correctly source variables based on `$ENVIRONMENT`.
+    * *Error:* Terraform initialization failure (backend configuration errors, unable to access S3 bucket or DynamoDB table).
+        * *Troubleshooting:* Verify bucket/table names and regions. Check IAM permissions for accessing the Terraform backend state.
+    * *Error:* Terraform refresh/apply failure (state lock, invalid Terraform code, AWS API errors, insufficient IAM permissions for `ec2:AuthorizeSecurityGroupIngress`/`ec2:DescribeSecurityGroups`, etc.).
+        * *Troubleshooting:* Check Terraform logs for details. Release state lock if necessary. Validate Terraform code (`terraform validate`). Ensure AWS credentials have permissions to modify the target security group.
+    * *Error:* Target `module.app.aws_security_group.bastion_sg` not found in Terraform state.
+        * *Troubleshooting:* Verify the Terraform module structure and resource naming is correct.
+
+---
+
+**8. Load Secrets and Set up SSH Key**
+* **Commands:** `cd infra`, `. ./load-secrets.sh`, `cd ..`, export secrets to `$GITHUB_ENV`, decode and save SSH key.
+* **Description:** Executes the `infra/load-secrets.sh` script, which is expected to fetch sensitive data (DB credentials, hostnames, bastion SSH private key) from AWS Secrets Manager or Parameter Store based on `$ENVIRONMENT`. It then exports these fetched values as masked environment variables for subsequent steps and decodes the base64 encoded bastion private key, saving it to `~/.ssh/id_rsa` with appropriate permissions (600).
+* **Inputs/Environment:** AWS Credentials, `$ENVIRONMENT`, script `infra/load-secrets.sh`. Assumes secrets exist in AWS.
+* **Expected Outcome:** Secrets like `$DATABASE_PASSWORD`, `$DATABASE_HOSTNAME`, `$BASTION_HOST_IP`, `$BASTION_PRIVATE_KEY` etc. are fetched and available as environment variables. The SSH private key file `~/.ssh/id_rsa` is created and configured.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* `load-secrets.sh` script fails (e.g., cannot connect to AWS, secret not found in Secrets Manager/Parameter Store, permission denied).
+        * *Troubleshooting:* Check the script's logic and logs. Verify the secrets exist in the expected AWS location for the given `$ENVIRONMENT`. Ensure AWS credentials have permissions (`secretsmanager:GetSecretValue` or `ssm:GetParameter`).
+    * *Error:* Base64 decoding fails (invalid `BASTION_PRIVATE_KEY` format).
+        * *Troubleshooting:* Ensure the secret stored in AWS is a valid base64 encoded private key.
+    * *Error:* Filesystem errors creating `~/.ssh` directory or writing `id_rsa` file.
+        * *Troubleshooting:* Check runner filesystem permissions (usually not an issue on standard runners).
+
+---
+
+**9. Run RDS Restore Script (Conditional)**
+* **Condition:** `if: github.event.inputs.create_backup_db == 'Yes'`
+* **Command:** `./infra/restore-rds.sh "${{ github.event.inputs.source_instance_id }}" "${{ github.event.inputs.snapshot_id }}"`
+* **Description:** If the user selected 'Yes' for `create_backup_db`, this step executes the main RDS restore script (`./infra/restore-rds.sh`), passing the source instance ID and target snapshot ID as arguments. The script contains the core logic for interacting with the AWS RDS API to perform the restore operation (likely `aws rds restore-db-instance-from-db-snapshot`). **The exact behavior (e.g., creating a *new* instance vs. restoring over an existing one) depends entirely on the content of `restore-rds.sh`.**
+* **Inputs/Environment:** AWS Credentials, `github.event.inputs.source_instance_id`, `github.event.inputs.snapshot_id`, depends on the implementation within `restore-rds.sh`.
+* **Expected Outcome:** An RDS instance is restored from the specified snapshot. This is often a long-running operation; the script might wait for completion or exit earlier.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* Script `./infra/restore-rds.sh` not found or not executable.
+        * *Troubleshooting:* Ensure the script exists, is checked into the repository, and has execute permissions (`chmod +x`).
+    * *Error:* AWS API errors during restore (snapshot not found, invalid source instance ID, instance identifier already exists, insufficient IAM permissions `rds:RestoreDBInstanceFromDBSnapshot`, RDS limits exceeded, incompatible parameters).
+        * *Troubleshooting:* Check the script's output for AWS error messages. Verify snapshot ID and source instance ID. Ensure the IAM user/role has RDS restore permissions. Check RDS console for conflicting instance names or resource limits.
+    * *Error:* Script timeout if it waits for instance availability, which can take a long time.
+        * *Troubleshooting:* Increase timeout settings if necessary, or modify the script to not wait.
+
+---
+
+**10. Run Migrations (Conditional)**
+* **Condition:** `if: github.event.inputs.apply_migration == 'Yes'`
+* **Commands:** `cd website`, `ssh-keyscan`, `ssh -L ...` (tunnel), `export DATABASE_URL`, `make migrate`, `make createpages`
+* **Description:** If the user selected 'Yes' for `apply_migration`, this step performs database migrations:
+    1.  Changes to the `website` directory.
+    2.  Adds the bastion host's SSH key to the runner's `known_hosts` file using `ssh-keyscan`.
+    3.  Establishes an SSH tunnel in the background (`-f -N`). It forwards connections from the runner's `localhost:5432` to the actual database host (`$DATABASE_HOSTNAME:5432`) via the bastion host (`$BASTION_HOST_IP`), using the SSH key set up earlier.
+    4.  Exports a `DATABASE_URL` environment variable pointing to `localhost:5432` using the fetched `$DATABASE_PASSWORD`.
+    5.  Runs `make migrate` (presumably executing `python manage.py migrate`) to apply Django database migrations using the tunnelled connection.
+    6.  Runs `make createpages settings="app.settings.${ENVIRONMENT}"`, a custom command likely performing post-migration data setup specific to the environment.
+* **Inputs/Environment:** `$BASTION_HOST_IP`, `$DATABASE_HOSTNAME`, `$DATABASE_PASSWORD`, `$ENVIRONMENT`, SSH key (`~/.ssh/id_rsa`), Python environment with dependencies, `website/Makefile`, `manage.py` script. Requires the bastion security group update (Step 7) to have succeeded. Requires the RDS instance (either pre-existing or restored in Step 9) to be available and accessible from the bastion.
+* **Expected Outcome:** Database schema migrations are applied, and any custom post-migration setup (`createpages`) is executed successfully.
+* **Potential Errors & Troubleshooting:**
+    * *Error:* `ssh-keyscan` fails (bastion host unreachable, DNS resolution issues).
+        * *Troubleshooting:* Verify `$BASTION_HOST_IP` is correct and reachable from the runner. Check network ACLs and Security Groups on the bastion.
+    * *Error:* SSH tunnel command fails (`ssh -L ...`):
+        * *Permission denied:* SSH key issue (`~/.ssh/id_rsa` incorrect, permissions wrong, key not authorized on bastion). Troubleshooting: Verify key generation/loading (Step 8). Check bastion's `~/.ssh/authorized_keys`.
+        * *Connection refused/timeout:* Bastion host down, port 22 blocked (check bastion SG, network ACLs), incorrect `$BASTION_HOST_IP`. Troubleshooting: Verify bastion status and network paths. Ensure Step 7 successfully allowed runner IP.
+        * *Host key verification failed:* Issue with `known_hosts` file or host key changing. `StrictHostKeyChecking=yes` requires the key scanned by `ssh-keyscan` to be correct. Troubleshooting: Ensure `ssh-keyscan` ran correctly. Clear `~/.ssh/known_hosts` if the key legitimately changed (use caution).
+        * *Address already in use:* Port 5432 on the runner is already bound. Troubleshooting: Unlikely in clean runner environment, but check for conflicting processes if debugging locally.
+    * *Error:* `make migrate` or `make createpages` fails:
+        * *Database connection error:* Tunnel not working, `$DATABASE_HOSTNAME` incorrect, database instance not running or accessible from bastion, incorrect `$DATABASE_PASSWORD`, wrong database name in `DATABASE_URL`. Troubleshooting: Verify tunnel status (`ps aux | grep ssh`). Check database status in AWS console. Ensure bastion's outbound rules allow connection to DB port. Verify credentials.
+        * *Migration script errors:* Syntax errors in Django migrations, logical errors in migration code, data conflicts. Troubleshooting: Examine Django migration logs. Test migrations locally or in a staging environment.
+        * *`createpages` command errors:* Issues specific to the custom logic in that command. Troubleshooting: Check the `make createpages` target in the Makefile and the corresponding Python script/management command.
+
+---
+
+## Important Considerations
+
+* **Security:** This workflow uses static AWS Access Keys stored as GitHub secrets. Consider migrating to OpenID Connect (OIDC) using `aws-actions/configure-aws-credentials` with `role-to-assume` for enhanced security (eliminates long-lived keys).
+* **Idempotency:** The `restore-rds.sh` script's behavior is critical. If it creates a *new* instance, running the workflow multiple times might create multiple restored instances. If it modifies an existing instance, it might be destructive. Ensure the script's behavior is well-understood.
+* **State Management:** Terraform is used for a targeted SG update. Ensure the Terraform state is managed correctly (S3 backend with locking is good practice, as used here).
+* **External Scripts:** The workflow heavily relies on the correctness and robustness of external scripts (`restore-rds.sh`, `load-secrets.sh`, `setup.sh`, `setup_zone.sh`, Makefiles). Errors within these scripts will cause workflow failures.
+* **Long-Running Operations:** RDS restore can take significant time. The workflow might time out if scripts wait synchronously without adequate timeout settings.
+* **Bastion Dependency:** Access to the database for migrations relies entirely on the bastion host being available and correctly configured, and the runner's IP being allowed through its security group.
+* **Dynamic Sandbox Environment:** Note that the GitHub Actions environment name for `sandbox` includes the triggering actor's username (`{github.actor}_sandbox`), making it specific to the user running the workflow.

--- a/docs/support/RDS-restore-steps.md
+++ b/docs/support/RDS-restore-steps.md
@@ -7,6 +7,8 @@ It's possible to perform the core actions of the Database restore workflow (rest
 ### Prerequisites
 
 - **AWS Credentials:** Configure AWS credentials locally with sufficient permissions for RDS restore, EC2 Security Group modifications, and potentially accessing secrets (e.g., via `aws configure`, or setting `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` environment variables).
+- **DATABASE_HOSTNAME:** Configure `DATABASE_HOSTNAME` in AWS Secrets manager for secret: `website_secrets`. This should be the restored Database hostname.
+- **BASTION_HOST_IP:** Configure `BASTION_HOST_IP` in AWS Secrets manager for secret: `website_secrets`.
 
 **Steps:**
 
@@ -27,6 +29,9 @@ The process typically involves three main `make` commands run in sequence:
 
 **2. Start SSH Tunnel:**
 
+> ![IMPORTANT]
+> Check you have rightly configured `BASTION_HOST_IP` in `website_secrets`.
+
 * **Purpose:** Prepares for database connection by:
     * Updating the bastion host's security group via Terraform to allow SSH from your *current* public IP.
     * Fetching necessary secrets (like bastion key, DB hostname - likely handled within the script).
@@ -46,6 +51,9 @@ The process typically involves three main `make` commands run in sequence:
 * **Outcome:** This command will print status messages and typically exit quickly after launching the SSH tunnel process in the background (using `ssh -f`). The tunnel forwarding `localhost:5432` to the database will remain active in the background.
 
 **3. Apply Migrations to Restored DB:**
+
+> ![IMPORTANT]
+> Check you have rightly configured `DATABASE_HOSTNAME` in `website_secrets`.
 
 * **Purpose:** Connects to the newly restored database (via the background tunnel established in Step 2) and applies database migrations and any custom setup commands (like `createpages`). Corresponds to the migration execution part of the "Run Migrations" step in the GitHub workflow.
 * **Command Syntax:**

--- a/docs/support/RDS-restore-steps.md
+++ b/docs/support/RDS-restore-steps.md
@@ -39,11 +39,7 @@ The process typically involves three main `make` commands run in sequence:
     * Adding the bastion's host key to `./infra/.ssh/known_hosts`.
     * Starting the SSH tunnel process **in the background**.
     Corresponds to the "Update Bastion SG", "Load Secrets/Set up SSH Key", and SSH tunnel setup parts of the GitHub workflow.
-* **Command Syntax:**
-    ```bash
-    make start-tunnel
-    ```
-* **Example:**
+* **Command:**
     ```bash
     make start-tunnel
     ```
@@ -56,11 +52,7 @@ The process typically involves three main `make` commands run in sequence:
 > Check that you have correctly configured `DATABASE_HOSTNAME` in `website_secrets`.
 
 * **Purpose:** Connects to the newly restored database (via the background tunnel established in Step 2) and applies database migrations and any custom setup commands (like `createpages`). Corresponds to the migration execution part of the "Run Migrations" step in the GitHub workflow.
-* **Command Syntax:**
-    ```bash
-    make apply-db-restore
-    ```
-* **Example:**
+* **Command:**
     ```bash
     make apply-db-restore
     ```

--- a/docs/support/RDS-restore-steps.md
+++ b/docs/support/RDS-restore-steps.md
@@ -30,7 +30,7 @@ The process typically involves three main `make` commands run in sequence:
 **2. Start SSH Tunnel:**
 
 > [!IMPORTANT]
-> Check you have rightly configured `BASTION_HOST_IP` in `website_secrets`.
+> Check that you have correctly configured `BASTION_HOST_IP` in `website_secrets`.
 
 * **Purpose:** Prepares for database connection by:
     * Updating the bastion host's security group via Terraform to allow SSH from your *current* public IP.
@@ -53,7 +53,7 @@ The process typically involves three main `make` commands run in sequence:
 **3. Apply Migrations to Restored DB:**
 
 > [!IMPORTANT]
-> Check you have rightly configured `DATABASE_HOSTNAME` in `website_secrets`.
+> Check that you have correctly configured `DATABASE_HOSTNAME` in `website_secrets`.
 
 * **Purpose:** Connects to the newly restored database (via the background tunnel established in Step 2) and applies database migrations and any custom setup commands (like `createpages`). Corresponds to the migration execution part of the "Run Migrations" step in the GitHub workflow.
 * **Command Syntax:**

--- a/docs/support/RDS-restore-steps.md
+++ b/docs/support/RDS-restore-steps.md
@@ -29,7 +29,7 @@ The process typically involves three main `make` commands run in sequence:
 
 **2. Start SSH Tunnel:**
 
-> ![IMPORTANT]
+> [!IMPORTANT]
 > Check you have rightly configured `BASTION_HOST_IP` in `website_secrets`.
 
 * **Purpose:** Prepares for database connection by:
@@ -52,7 +52,7 @@ The process typically involves three main `make` commands run in sequence:
 
 **3. Apply Migrations to Restored DB:**
 
-> ![IMPORTANT]
+> [!IMPORTANT]
 > Check you have rightly configured `DATABASE_HOSTNAME` in `website_secrets`.
 
 * **Purpose:** Connects to the newly restored database (via the background tunnel established in Step 2) and applies database migrations and any custom setup commands (like `createpages`). Corresponds to the migration execution part of the "Run Migrations" step in the GitHub workflow.

--- a/infra/apply-migrations-to-restored-db.sh
+++ b/infra/apply-migrations-to-restored-db.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source ./setup.sh
+
+echo "Exporting DATABASE_URL for local connection through tunnel..."
+export DATABASE_URL="postgresql://master:${DATABASE_PASSWORD}@localhost:5432/postgres"
+
+echo "DATABASE_URL exported."
+echo "Running database migrations (make migrate)..."
+
+cd ../website
+make migrate || { echo "ERROR: 'make migrate' failed"; exit 1; }
+echo "'make migrate' completed."
+echo "Running custom commands (make createpages)..."
+
+make createpages settings="app.settings.${ENVIRONMENT}" || { echo "ERROR: 'make createpages' failed"; exit 1; }
+echo "'make createpages' completed."
+echo "Migration step finished successfully."
+
+echo "Applied Migrations to database ${DATABASE_HOSTNAME}."

--- a/infra/ssh-tunnel.sh
+++ b/infra/ssh-tunnel.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+source ./setup.sh
+
+source ./setup_zone.sh
+
+./update-deployer-policy.sh
+
+terraform init \
+    -upgrade \
+    -backend=true \
+    -backend-config=bucket="${STATE_BUCKET}" \
+    -backend-config=key="${KEY}" \
+    -backend-config=dynamodb_table="${LOCK_TABLE}" \
+    -backend-config=region="${REGION}"
+
+terraform refresh
+
+echo "Applying targeted update to Bastion Security Group..."
+terraform apply -target=module.app.aws_security_group.bastion_sg -auto-approve
+
+echo "Bastion Security Group update applied."
+
+mkdir -p .ssh
+echo "${BASTION_PRIVATE_KEY}" | base64 --decode > .ssh/id_rsa
+chmod 600 .ssh/id_rsa
+echo "Bastion private key configured."
+
+ssh-keyscan -H ${BASTION_HOST_IP} > .ssh/known_hosts || { echo "ERROR: ssh-keyscan failed for ${BASTION_HOST_IP}"; exit 1; }
+echo "Host key scanned and added."
+
+echo "SSH tunnel opened in background. Connect in localhost:5432 ..."
+
+ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=.ssh/known_hosts \
+    -L 5432:${DATABASE_HOSTNAME}:5432 \
+    -N -q -i .ssh/id_rsa ubuntu@${BASTION_HOST_IP} || {
+      echo "ERROR: SSH tunnel command failed or was interrupted."
+      exit 1;
+    }
+
+# This part of the script will only be reached AFTER you press Ctrl+C
+# or if the SSH connection breaks for another reason.
+echo "SSH tunnel closed."
+
+exit 0


### PR DESCRIPTION
## Changes

- Modify the Restore RDS workflow to accept input parameters
    - Source RDS Instance ID: _string, mandatory_
    - RDS Snapshot ID to restore from: _string, mandatory_
    - Create backup DB?: _boolean, default: Yes_
    - Apply Database Migrations?: _boolean, default: No_
 - The workflow creates a backup DB from restore snapshot.
 - The workflow applies migrations on the restored DB.

## Testing

The restore process can be run either all in local or as a Github action workflow.

### Running in local

- First, create restore DB:

```shell
> make create-db-restore sandbox-20250503200625381200000001 rds:sandbox-20250503200625381200000001-2025-05-03-20-10
```

- Second, start tunnel to connect restored DB.

```shell
> make start-tunnel 
Starting SSH tunnel to bastion host...
...
Bastion private key configured.
Host key scanned and added.
SSH tunnel opened in background. Connect in localhost:5432 ...
```

- Finally, run migration/createpages command on the restored DB:

```shell
> make apply-db-restore 
Restoring database for environment: sandbox
Exporting DATABASE_URL for local connection through tunnel...
...
'make createpages' completed.
Migration step finished successfully.
Applied Migrations to database sandbox-20250503200625381200000001-restored.c1o2cqieavi7.us-east-1.rds.amazonaws.com.
```

### Running in Github workflow

https://github.com/ustaxcourt/website-wagtail/actions/runs/14815687383/job/41595758523

<img width="326" alt="image" src="https://github.com/user-attachments/assets/1a194052-614a-433a-81ef-18c5225229f6" />
