### PR TITLE
Add logic to only show no-index tags prior to prod environment

### DIFF
--- a/website/app/templates/500.html
+++ b/website/app/templates/500.html
@@ -2,7 +2,11 @@
 <html lang="en" dir="ltr">
     <head>
         <meta charset="utf-8" />
-        <meta name="robots" content="noindex">
+        <!-- Below code (next 4 lines) commented until go-live to keep production environment unindexed. Uncomment code and remove this line at that time :) -->
+        <!-- {% get_enviroment as environment %}
+        {% if environment != "production-yet" %} -->
+            <meta name="google-site-verification" content="alipAPhtm5ugza9OWr54BwvB3FkPOhwNXYitjmnf6Pk" />
+        <!-- {% endif %} -->
         <meta name="google-site-verification" content="alipAPhtm5ugza9OWr54BwvB3FkPOhwNXYitjmnf6Pk" />
         <title>Internal server error</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/website/app/templates/500.html
+++ b/website/app/templates/500.html
@@ -2,11 +2,10 @@
 <html lang="en" dir="ltr">
     <head>
         <meta charset="utf-8" />
-        <!-- Below code (next 4 lines) commented until go-live to keep production environment unindexed. Uncomment code and remove this line at that time :) -->
-        <!-- {% get_enviroment as environment %}
-        {% if environment != "production-yet" %} -->
+        {% get_enviroment as environment %}
+        {% if environment != "production-yet" %}
             <meta name="google-site-verification" content="alipAPhtm5ugza9OWr54BwvB3FkPOhwNXYitjmnf6Pk" />
-        <!-- {% endif %} -->
+        {% endif %}
         <meta name="google-site-verification" content="alipAPhtm5ugza9OWr54BwvB3FkPOhwNXYitjmnf6Pk" />
         <title>Internal server error</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/website/app/templates/base.html
+++ b/website/app/templates/base.html
@@ -3,8 +3,12 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <meta name="robots" content="noindex">
         <meta name="google-site-verification" content="alipAPhtm5ugza9OWr54BwvB3FkPOhwNXYitjmnf6Pk" />
+        <!-- Below code (next 4 lines) commented until go-live to keep production environment unindexed. Uncomment code and remove this line at that time :) -->
+        <!-- {% get_enviroment as environment %}
+        {% if environment != "production-yet" %} -->
+            <meta name="robots" content="noindex">
+        <!-- {% endif %} -->
         <title>
             {% block title %}
                 {% if page.seo_title %}

--- a/website/app/templates/base.html
+++ b/website/app/templates/base.html
@@ -4,11 +4,10 @@
     <head>
         <meta charset="utf-8" />
         <meta name="google-site-verification" content="alipAPhtm5ugza9OWr54BwvB3FkPOhwNXYitjmnf6Pk" />
-        <!-- Below code (next 4 lines) commented until go-live to keep production environment unindexed. Uncomment code and remove this line at that time :) -->
-        <!-- {% get_enviroment as environment %}
-        {% if environment != "production-yet" %} -->
+        {% get_enviroment as environment %}
+        {% if environment != "production-yet" %}
             <meta name="robots" content="noindex">
-        <!-- {% endif %} -->
+        {% endif %}
         <title>
             {% block title %}
                 {% if page.seo_title %}


### PR DESCRIPTION
Note that the check is for "production-yet" environment. Following existing pattern to apply rule to every environment except production once we go live. All checks with production-yet will be updated as part of final go-live activities (documented [here](https://ustc-isd.monday.com/docs/8977632572?blockId=53762154-a1f7-4191-abed-e26cb90607c4)).