### PR TITLE
Simplify the Document Upload Method

### DIFF
--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -85,6 +85,8 @@ jobs:
           cd infra
           . ./load-secrets.sh
           cd ..
+          echo "DOMAIN_NAME=$DOMAIN_NAME" >> $GITHUB_ENV
+          echo "::add-mask::${DOMAIN_NAME}"
           echo "DATABASE_PASSWORD=$DATABASE_PASSWORD" >> $GITHUB_ENV
           echo "::add-mask::${DATABASE_PASSWORD}"
           echo "DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD" >> $GITHUB_ENV

--- a/website/home/management/commands/pages/about_the_court/fees_and_charges_page.py
+++ b/website/home/management/commands/pages/about_the_court/fees_and_charges_page.py
@@ -37,7 +37,11 @@ class FeesAndChargesPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in documents.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             documents[document] = uploaded_document.file.url
             documents_ids[document] = uploaded_document.id
 

--- a/website/home/management/commands/pages/about_the_court/history_page.py
+++ b/website/home/management/commands/pages/about_the_court/history_page.py
@@ -59,9 +59,9 @@ class HistoryPageInitializer(PageInitializer):
 
         for item in info:
             document = self.load_document_from_documents_dir(
-                None,
-                item["document"],
-                item["title"],
+                subdirectory=None,
+                filename=item["document"],
+                title=item["title"],
             )
 
             info_links.append(

--- a/website/home/management/commands/pages/about_the_court/holidays_page.py
+++ b/website/home/management/commands/pages/about_the_court/holidays_page.py
@@ -34,7 +34,11 @@ class HolidaysPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             docs[document] = uploaded_document.file.url
 
         new_page = home_page.add_child(

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_faqs_account_management_page.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_faqs_account_management_page.py
@@ -37,7 +37,11 @@ class DawsonFaqsAccountManagementPageInitializer(PageInitializer):
         ).first()
 
         for document in dawson_faqs_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             dawson_faqs_docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_faqs_training_and_support.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_faqs_training_and_support.py
@@ -39,7 +39,11 @@ class DawsonFaqsTrainingAndSupportPageInitializer(PageInitializer):
         ).first()
 
         for document in dawson_faqs_training_and_support_doc.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             dawson_faqs_training_and_support_doc[document] = uploaded_document.file.url
 
             body_content = [

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_terms_of_use.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_terms_of_use.py
@@ -31,7 +31,11 @@ class DawsonTermsOfUsePageInitializer(PageInitializer):
 
         # Load Rule 21 document
         for document in terms_of_use_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             terms_of_use_docs[document] = uploaded_document.file.url
 
         new_page = home_page.add_child(

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/definitions_page.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/definitions_page.py
@@ -25,7 +25,12 @@ class DawsonFaqsDefinitionsPageInitializer(PageInitializer):
         """generate the definitions page"""
 
         definition_docs = {
-            doc: self.load_document_from_documents_dir(None, doc, doc) for doc in docs
+            doc: self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=doc,
+                title=doc,
+            )
+            for doc in docs
         }
 
         page_body = (

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/documents_eligible_for_efiling_page.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/documents_eligible_for_efiling_page.py
@@ -29,10 +29,11 @@ class DocumentsEligibleEfilingPageInitializer(PageInitializer):
 
         logger.info(f"Creating the '{title}' page.")
 
-        # Fetch the CSV document instance
         csv_document = self.load_document_from_documents_dir(
-            subdirectory=None, filename="efiling_eligible_documents_list.csv"
-        )  # Removed trailing comma
+            subdirectory=None,
+            filename="efiling_eligible_documents_list.csv",
+            title="efiling_eligible_documents_list.csv",
+        )
 
         new_page = home_page.add_child(
             instance=CSVUploadPage(

--- a/website/home/management/commands/pages/home_page.py
+++ b/website/home/management/commands/pages/home_page.py
@@ -72,7 +72,11 @@ class HomePageInitializer(PageInitializer):
             logger.info("Updated default site root to the new Home page.")
 
         for document in home_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             home_docs[document] = uploaded_document.file.url
 
         # delete the wagtail generated page (it doesn't have the mixin)

--- a/website/home/management/commands/pages/orders_and_opinions/citation_style_manual_page.py
+++ b/website/home/management/commands/pages/orders_and_opinions/citation_style_manual_page.py
@@ -26,9 +26,9 @@ class CitationStyleManualPageInitializer(PageInitializer):
 
         # Load the PDF document
         document = self.load_document_from_documents_dir(
-            None,
-            "USTC_Citation_and_Style_Manual_modified_2024.09.pdf",
-            "USTC Citation and Style Manual",
+            subdirectory=None,
+            filename="USTC_Citation_and_Style_Manual_modified_2024.09.pdf",
+            title="USTC Citation and Style Manual",
         )
 
         if not document:

--- a/website/home/management/commands/pages/page_initializer.py
+++ b/website/home/management/commands/pages/page_initializer.py
@@ -59,7 +59,7 @@ class PageInitializer(ABC):
         return collection
 
     def load_document_from_documents_dir(
-        self, subdirectory, filename, title=None, collection=None, restriction_type=None
+        self, subdirectory, filename, title, collection=None, restriction_type=None
     ):
         """
         Load a document from the documents directory and create a Wagtail Document instance.
@@ -67,7 +67,7 @@ class PageInitializer(ABC):
         Args:
             subdirectory (str): Subdirectory under DOCUMENTS_BASE_PATH
             filename (str): Name of the file to load
-            title (str, optional): Title for the document. If None, uses filename without extension
+            title (str): Title for the document.
 
         Returns:
             Document: The created document instance or None if file not found or already exists
@@ -84,10 +84,6 @@ class PageInitializer(ABC):
         if not os.path.exists(file_path):
             logger.warning(f"Document file not found at {file_path}")
             return None
-
-        if title is None:
-            # Use filename without extension as title
-            title = os.path.splitext(filename)[0].replace("_", " ")
 
         Document = get_document_model()
 

--- a/website/home/management/commands/pages/rules_and_guidance/clinics_academic_non_law_school_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/clinics_academic_non_law_school_page.py
@@ -33,7 +33,11 @@ class ClinicsAcademicNonLawSchoolPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/clinics_academic_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/clinics_academic_page.py
@@ -32,7 +32,11 @@ class ClinicsAcademicPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/clinics_calendar_call_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/clinics_calendar_call_page.py
@@ -30,7 +30,11 @@ class ClinicsCalendarCallPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/clinics_chief_counsel_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/clinics_chief_counsel_page.py
@@ -30,7 +30,11 @@ class ClinicsChiefCounselPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/clinics_nonacademic_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/clinics_nonacademic_page.py
@@ -32,7 +32,11 @@ class ClinicsNonAcademicPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/clinics_pro_bono_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/clinics_pro_bono_page.py
@@ -30,7 +30,11 @@ class ClinicsProBonoProgramsPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             docs[document] = uploaded_document.file.url
 
         home_page.add_child(

--- a/website/home/management/commands/pages/rules_and_guidance/comments_and_suggestions_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/comments_and_suggestions_page.py
@@ -79,7 +79,11 @@ class CommentsAndSuggestionsPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             docs[document] = uploaded_document.file.url
 
         new_page = home_page.add_child(

--- a/website/home/management/commands/pages/rules_and_guidance/judicial_conduct_and_disability_procedures_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/judicial_conduct_and_disability_procedures_page.py
@@ -31,7 +31,11 @@ class JudicialConductAndDisabilityProceduresPageInitializer(PageInitializer):
         logger.info(f"Creating the '{title}' page.")
 
         for document in jcdp_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             jcdp_docs[document] = uploaded_document.file.url
 
         body_text = (

--- a/website/home/management/commands/pages/rules_and_guidance/petitioners_about_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/petitioners_about_page.py
@@ -35,7 +35,11 @@ class PetitionersAboutInitializer(PageInitializer):
         ).first()
 
         for document in petitioners_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             petitioners_docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/petitioners_after_trial_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/petitioners_after_trial_page.py
@@ -37,7 +37,11 @@ class PetitionersAfterTrialInitializer(PageInitializer):
         ).first()
 
         for document in petitioners_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             petitioners_docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/petitioners_before_trial_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/petitioners_before_trial_page.py
@@ -43,7 +43,11 @@ class PetitionersBeforeTrialInitializer(PageInitializer):
         ).first()
 
         for document in petitioners_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             petitioners_docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/petitioners_glossary_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/petitioners_glossary_page.py
@@ -46,7 +46,11 @@ class PetitionersGlossaryPageInitializer(PageInitializer):
         ).first()
 
         for document in petitioners_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             petitioners_docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/petitioners_start_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/petitioners_start_page.py
@@ -50,7 +50,11 @@ class PetitionersStartPageInitializer(PageInitializer):
         ).first()
 
         for document in petitioners_docs.keys():
-            uploaded_document = self.load_document_from_documents_dir(None, document)
+            uploaded_document = self.load_document_from_documents_dir(
+                subdirectory=None,
+                filename=document,
+                title=document,
+            )
             petitioners_docs[document] = uploaded_document.file.url
 
         questions = [

--- a/website/home/management/commands/pages/rules_and_guidance/remote_proceedings_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/remote_proceedings_page.py
@@ -63,9 +63,9 @@ class RemoteProceedingsPageInitializer(PageInitializer):
 
         for info in info:
             document = self.load_document_from_documents_dir(
-                None,
-                info["document"],
-                info["title"],
+                subdirectory=None,
+                filename=info["document"],
+                title=info["title"],
             )
 
             info_links.append(

--- a/website/home/management/commands/pages/rules_and_guidance/rules_page.py
+++ b/website/home/management/commands/pages/rules_and_guidance/rules_page.py
@@ -1813,7 +1813,9 @@ class RulesPageInitializer(PageInitializer):
                 for link in section["value"]["links"]:
                     if link["document"]:
                         uploaded_document = self.load_document_from_documents_dir(
-                            subdirectory=None, filename=link["document"]
+                            subdirectory=None,
+                            filename=link["document"],
+                            title=link["document"],
                         )
                         link["document"] = uploaded_document.id
 


### PR DESCRIPTION
the load_document_from_documents_dir method used to allow an option title.  This PR changes it to be required because some of our pages were created without specifying the title and with.  When you didn't specify the title, it would take the file name and strip the extension to use as the file name.  This caused issues with us developers creating what we thought was a reused file when in reality it would create a brand new one.

We should clear the pages and documents before deploying.