### PR TITLE
Bug - Opening Document in New Tab 

### DIFF
--- a/website/app/templates/base.html
+++ b/website/app/templates/base.html
@@ -2,6 +2,89 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <script>
+            /**
+             * Register our link handlers after GA is fully loaded
+             */
+            function setupLinkHandlers() {
+                // Use event delegation instead of querySelectorAll
+                document.addEventListener('click', function(event) {
+                    const link = event.target.closest('a');
+                    if (!link) return;
+
+                    const href = link.getAttribute('href');
+                    if (!href) return;
+
+                    // For same-domain PDFs, let GA track first
+                    if (isSamedomain(href) && isPdf(href)) {
+                        window.open(href, '_blank');
+                        event.preventDefault();
+                        return;
+                    }
+
+                    if (href.startsWith('mailto:') || href.startsWith('tel:') || isSamedomain(href)) {
+                        return; // Let default behavior and GA handle these
+                    }
+
+                    // Handle external links
+                    event.preventDefault();
+                    if (isSubdomain(href)) {
+                        window.open(href, '_blank');
+                    } else {
+                        const newTab = window.open('/redirect/', '_blank');
+                        if (newTab) {
+                            newTab.sessionStorage.setItem('redirect_url', href);
+                        } else {
+                            alert('Pop-up blocked! Please allow pop-ups for this site.');
+                        }
+                    }
+                });
+            }
+
+            function getRootDomain(url) {
+                try {
+                    let hostname = new URL(url, window.location.origin).hostname;
+                    let parts = hostname.split(".").reverse();
+
+                    if (parts.length >= 2) {
+                        return parts[1] + "." + parts[0]
+                    }
+                    return hostname
+                } catch (e) {
+                    return null
+                }
+            }
+
+            function isSamedomain(url) {
+                let currentDomain = window.location.hostname;
+                let s3StaticDomainPattern = /.*ustc-website-assets\.s3\.amazonaws\.com$/;
+                let linkDomain;
+
+                try {
+                    linkDomain = new URL(url, window.location.origin).hostname;
+                } catch (e) {
+                    return true;
+                }
+
+                return (linkDomain === currentDomain || s3StaticDomainPattern.test(linkDomain));
+            }
+
+            function isSubdomain(url) {
+                let currentRootDomain = getRootDomain(window.location.hostname);
+                let linkRootDomain = getRootDomain(url);
+
+                return linkRootDomain && linkRootDomain === currentRootDomain;
+            }
+
+            function isPdf(url) {
+                return url.toLowerCase().endsWith('.pdf')
+            }
+
+            // Queue the setup to run after GA loads
+            window.gaCallbacks = window.gaCallbacks || [];
+            window.gaCallbacks.push(setupLinkHandlers);
+        </script>
+
         <meta charset="utf-8" />
         {% get_enviroment as environment %}
         {% if environment != "production-yet" %}
@@ -126,85 +209,3 @@
         {% block extra_js %}{# Override this in templates to add extra javascript #}{% endblock %}
     </body>
 </html>
-<script>
-    /**
-     * Register our link handlers after GA is fully loaded
-     */
-    function setupLinkHandlers() {
-        // Use event delegation instead of querySelectorAll
-        document.addEventListener('click', function(event) {
-            const link = event.target.closest('a');
-            if (!link) return;
-
-            const href = link.getAttribute('href');
-            if (!href) return;
-
-            // For same-domain PDFs, let GA track first
-            if (isSamedomain(href) && isPdf(href)) {
-                window.open(href, '_blank');
-                event.preventDefault();
-                return;
-            }
-
-            if (href.startsWith('mailto:') || href.startsWith('tel:') || isSamedomain(href)) {
-                return; // Let default behavior and GA handle these
-            }
-
-            // Handle external links
-            event.preventDefault();
-            if (isSubdomain(href)) {
-                window.open(href, '_blank');
-            } else {
-                const newTab = window.open('/redirect/', '_blank');
-                if (newTab) {
-                    newTab.sessionStorage.setItem('redirect_url', href);
-                } else {
-                    alert('Pop-up blocked! Please allow pop-ups for this site.');
-                }
-            }
-        });
-    }
-
-    function getRootDomain(url) {
-        try {
-            let hostname = new URL(url, window.location.origin).hostname;
-            let parts = hostname.split(".").reverse();
-
-            if (parts.length >= 2) {
-                return parts[1] + "." + parts[0]
-            }
-            return hostname
-        } catch (e) {
-            return null
-        }
-    }
-
-    function isSamedomain(url) {
-        let currentDomain = window.location.hostname;
-        let s3StaticDomainPattern = /.*ustc-website-assets\.s3\.amazonaws\.com$/;
-        let linkDomain;
-
-        try {
-            linkDomain = new URL(url, window.location.origin).hostname;
-        } catch (e) {
-            return true;
-        }
-
-        return (linkDomain === currentDomain || s3StaticDomainPattern.test(linkDomain));
-    }
-
-    function isSubdomain(url) {
-        let currentRootDomain = getRootDomain(window.location.hostname);
-        let linkRootDomain = getRootDomain(url);
-
-        return linkRootDomain && linkRootDomain === currentRootDomain;
-    }
-
-    function isPdf(url) {
-        return url.toLowerCase().endsWith('.pdf')
-    }
-
-    // Queue the setup to run after GA loads
-    window.gaCallbacks = window.gaCallbacks || [];
-    window.gaCallbacks.push(setupLinkHandlers);
-</script>

--- a/website/app/templates/google_analytics.html
+++ b/website/app/templates/google_analytics.html
@@ -10,7 +10,6 @@
         gtag('js', new Date());
         gtag('config', '{{ ga4_id }}');
 
-        // More reliable way to know GA is fully initialized
         gtag('get', '{{ ga4_id }}', 'client_id', function() {
             window.gaCallbacks.forEach(callback => callback());
             window.gaCallbacks = [];


### PR DESCRIPTION
there is a race condition where the click listener callbacks were being invoked before the GA script was done loading which broke the open in new tab logic. This moves that click listener logic to the top of the head before all other scripts so that it's gauarteed the browser will parse it first before loading GA.

Usually loading scripts without a defer is a bad practice because the HTML parsing will block, but the script is so simple I do not think it'll cause any noticable slowdown.