### PR TITLE
Fix: Prevent duplicate homepage entries by comparing normalized PDF filenames and titles with press release entries.

### DIFF
--- a/website/home/management/commands/pages/home_page.py
+++ b/website/home/management/commands/pages/home_page.py
@@ -126,7 +126,7 @@ class HomePageInitializer(PageInitializer):
             homepage=homepage,
             title="Tax Court disciplinary matters.",
             body=(
-                f"""See the <a href="{home_docs["04292025.pdf"]}" target="_blank">Press Release</a>."""
+                f"""See the <a href="{home_docs["04292025.pdf"]}" target="_blank" title="Press Release">Press Release</a>."""
             ),
             start_date=datetime(2025, 4, 29).date(),
             end_date=None,
@@ -136,7 +136,7 @@ class HomePageInitializer(PageInitializer):
             homepage=homepage,
             title="The Tax Court announced that Chief Special Trial Judge Lewis R. Carluzzo has decided to step down as Chief Special Trial Judge, effective May 2, 2025, and that Special Trial Judge Zachary S. Fried has been named Chief Special Trial Judge, effective May 3, 2025.",
             body=(
-                f"""See the <a href="{home_docs["04162025.pdf"]}" target="_blank">Press Release</a>."""
+                f"""See the <a href="{home_docs["04162025.pdf"]}" target="_blank" title="Press Release">Press Release</a>."""
             ),
             start_date=datetime(2025, 4, 14).date(),
             end_date=None,
@@ -146,7 +146,7 @@ class HomePageInitializer(PageInitializer):
             homepage=homepage,
             title="Tax Court Judge Julian I. Jacobs passed away on April 5, 2025",
             body=(
-                f"""See the <a href="{home_docs["04072025.pdf"]}" target="_blank">Press Release</a>."""
+                f"""See the <a href="{home_docs["04072025.pdf"]}" target="_blank" title="Press Release">Press Release</a>."""
             ),
             start_date=datetime(2025, 4, 7).date(),
             end_date=datetime(2025, 5, 5).date(),

--- a/website/home/models.py
+++ b/website/home/models.py
@@ -1587,7 +1587,6 @@ class PressReleasePage(RoutablePageMixin, EnhancedStandardPage):
                 pdf_filename,
             ) in seen_press_release_keys
             if is_duplicate:
-                print(f"Skipping duplicate homepage entry: {title} -> {pdf_filename}")
                 continue
 
             if not is_duplicate:


### PR DESCRIPTION
Fix: Deduplicate homepage and press release entries by matching PDF filenames and titles.

- Extract only the PDF filename (not full URL path) for accurate comparison
- Normalize file names and titles to lowercase for consistent matching
- Avoid duplicate entries when the same file appears in both press releases and homepage