### PR TITLE
reactivate prod-web: modify base_url and re-add banner

### DIFF
--- a/website/app/settings/production.py
+++ b/website/app/settings/production.py
@@ -12,4 +12,4 @@ BASE_URL = f'https://{os.getenv("DOMAIN_NAME")}'
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-WAGTAILADMIN_BASE_URL = f"https://{os.getenv('DOMAIN_NAME')}"
+WAGTAILADMIN_BASE_URL = "http://prod-web.ustaxcourt.com"

--- a/website/app/templates/base.html
+++ b/website/app/templates/base.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="utf-8" />
         {% get_enviroment as environment %}
-        {% if environment != "production" %}
+        {% if environment != "production-yet" %}
             <meta name="robots" content="noindex">
         {% endif %}
         <title>
@@ -105,7 +105,7 @@
     <body class="{% block body_class %}  {% endblock %}">
         {% include 'banner.html' %}
         {% get_enviroment as environment %}
-        {% if environment != "production" %}
+        {% if environment != "production-yet" %}
             {% include 'alert_banner.html' %}
         {% endif %}
         {% include 'header.html' %}


### PR DESCRIPTION
These changes are necessary in order to reactivate the production website on prod-web.ustaxcourt.gov

- re-add the "just for testing" banner at top of page
- revert the wagtail admin base_url value