### PR TITLE
OPTIONAL: Add commands to preregister users and superusers to production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,8 +112,8 @@ jobs:
           make superuser settings="app.settings.${ENVIRONMENT}"|| echo "user already exists, skipping"
           make resetadminpassword settings="app.settings.${ENVIRONMENT}"
           make createpages settings="app.settings.${ENVIRONMENT}"
-          make preregisterusers
-          make preregistersuperusers
+          make preregisterusers settings="app.settings.${ENVIRONMENT}"
+          make preregistersuperusers settings="app.settings.${ENVIRONMENT}"
 
       # TODO: disabling for now because of An error occurred (IncorrectInstanceState) when calling the StopInstances operation: This instance 'i-02e10df312188338c' is not in a state from which it can be stopped.
       # TODO: disable this for security reasons

--- a/.github/workflows/production_deploy.yml
+++ b/.github/workflows/production_deploy.yml
@@ -135,6 +135,8 @@ jobs:
           make migrate
           make superuser settings="app.settings.${ENVIRONMENT}" password=${DJANGO_SUPERUSER_PASSWORD} || echo "user already exists, skipping"
           make createpages settings="app.settings.${ENVIRONMENT}"
+          make preregisterusers settings="app.settings.${ENVIRONMENT}"
+          make preregistersuperusers settings="app.settings.${ENVIRONMENT}"
 
       - name: Manually Deploy ECS Task (Post-Migration)
         env:

--- a/website/Makefile
+++ b/website/Makefile
@@ -106,7 +106,7 @@ collectstatic:
 	. $(VENV) && python manage.py collectstatic --noinput --clear
 
 preregisterusers:
-	. $(VENV) && python manage.py preregister_users
+	. $(VENV) && DJANGO_SETTINGS_MODULE=$${settings:-app.settings.local} python manage.py preregister_users
 
 preregistersuperusers:
-	. $(VENV) && python manage.py preregister_superusers
+	. $(VENV) && DJANGO_SETTINGS_MODULE=$${settings:-app.settings.local} python manage.py preregister_superusers


### PR DESCRIPTION
Code changes allow users to be registered through secrets. See below notes from PR to add same commands to deploy.yml (for lower environments). This PR is an option, should only be merged if we decide on this approach. 

Strategy:

New make command to pre-register superusers based on JSON stored in Secrets Manager
New make command to pre-register users based on JSON stored in Secrets Manager with groups assigned
Both scripts are included as a step in the deploy.yml file
base.py is updated to alter the social auth pipeline to check for existing users to match Azure SSO login to by email. Also adjusted to full emails as usernames by default. This allows the first login via SSO to be completed with role assigned.
If no secret is provided, or the value is blank, the deployment will run as usual.
See ReadMe for more details.
Sample JSON for secret values:

SUPERUSERS_TO_PREREGISTER:
[ "superuser1@example.com", "superuser2@example.com" ]

USERS_TO_PREREGISTER:
{ "Editors": [ "editor1@example.com", "john.doe@example.com" ], "Moderators": [ "moderator_a@example.com", "editor1@example.com" ] }