### PR TITLE
Bug: editing a snippet does not force a cache update

### DIFF
--- a/website/home/wagtail_hooks.py
+++ b/website/home/wagtail_hooks.py
@@ -114,10 +114,14 @@ def purge_cache_for_snippet_related_pages(request, instance):
     snippet_type = type(instance).__name__.lower()
 
     path_map = {
-        "commontext": ["/"],
-        "judgecollection": ["/judges/"],
-        "judgeprofile": ["/judges/"],
-        "judgerole": ["/judges/"],
+        "commontext": ["/*"],
+        "fancycard": ["/*"],
+        "judgecollection": ["/judges/*"],
+        "judgeprofile": ["/judges/*"],
+        "judgerole": ["/judges/*"],
+        "navigationmenu": ["/*"],
+        "navigationribbon": ["/*"],
+        "simplecard": ["/*"],
     }
 
     affected_prefixes = path_map.get(snippet_type, ["/"])
@@ -135,4 +139,4 @@ def purge_cache_for_snippet_related_pages(request, instance):
             purge_page_from_cache(page)
             logger.info(f"Purged frontend cache for page: {page.url_path}")
         except Exception as e:
-            logger.warning(f"Error purging cache for page {page.id}: {e}")
+            logger.error(f"Error purging cache for page {page.id}: {e}")


### PR DESCRIPTION
- Implemented an after_edit_snippet hook to purge the frontend cache for pages potentially affected by snippet changes. 

- Ensures that edits to snippets are reflected on the live site immediately by clearing the frontend cache.

Snippet types covered:
- Common texts
- Fancy cards
- Judge collections
- Judge profiles
- Judge roles
- Navigation menus
- Navigation ribbons
- Simple cards