### PR TITLE
Prevent creation/recreation of Snippets post SITE GOLIVE date

### DIFF
--- a/website/app/settings/base.py
+++ b/website/app/settings/base.py
@@ -17,6 +17,7 @@ import dj_database_url
 import json
 import urllib.request
 from pythonjsonlogger import jsonlogger
+from datetime import date
 
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -409,3 +410,5 @@ LOGGING = {
         },
     },
 }
+
+IS_SITE_LIVE = date.today() >= date(2025, 6, 1)

--- a/website/app/settings/base.py
+++ b/website/app/settings/base.py
@@ -411,4 +411,4 @@ LOGGING = {
     },
 }
 
-IS_SITE_LIVE = date.today() >= date(2025, 6, 1)
+SITE_IS_LIVE = date.today() >= date(2025, 6, 1)

--- a/website/app/settings/local.py
+++ b/website/app/settings/local.py
@@ -2,6 +2,7 @@ from .base import *  # noqa: F403
 from .base import LOGGING  # noqa: F403
 import os
 import subprocess
+from datetime import date
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -29,3 +30,5 @@ LOGGING["loggers"]["wagtail"]["handlers"] = ["simple"]
 LOGGING["loggers"]["home"]["handlers"] = ["simple"]
 LOGGING["loggers"]["home"]["level"] = "DEBUG"
 LOGGING["loggers"]["home.management.commands"]["level"] = "DEBUG"
+
+IS_SITE_LIVE = date.today() >= date(2999, 6, 1)

--- a/website/app/settings/local.py
+++ b/website/app/settings/local.py
@@ -31,4 +31,4 @@ LOGGING["loggers"]["home"]["handlers"] = ["simple"]
 LOGGING["loggers"]["home"]["level"] = "DEBUG"
 LOGGING["loggers"]["home.management.commands"]["level"] = "DEBUG"
 
-IS_SITE_LIVE = date.today() >= date(2999, 6, 1)
+SITE_IS_LIVE = date.today() >= date(2999, 6, 1)

--- a/website/app/settings/sandbox.py
+++ b/website/app/settings/sandbox.py
@@ -18,4 +18,4 @@ ENVIRONMENT = "sandbox"
 
 MIDDLEWARE = ["app.middleware.JSONExceptionMiddleware"] + MIDDLEWARE
 
-IS_SITE_LIVE = date.today() >= date(2999, 6, 1)
+SITE_IS_LIVE = date.today() >= date(2999, 6, 1)

--- a/website/app/settings/sandbox.py
+++ b/website/app/settings/sandbox.py
@@ -1,6 +1,7 @@
 from .base import *  # noqa: F403
 from .base import MIDDLEWARE
 import os
+from datetime import date
 
 
 try:
@@ -16,3 +17,5 @@ BASE_URL = f'https://{os.getenv("DOMAIN_NAME")}'
 ENVIRONMENT = "sandbox"
 
 MIDDLEWARE = ["app.middleware.JSONExceptionMiddleware"] + MIDDLEWARE
+
+IS_SITE_LIVE = date.today() >= date(2999, 6, 1)

--- a/website/home/management/commands/create_pages.py
+++ b/website/home/management/commands/create_pages.py
@@ -149,9 +149,9 @@ class Command(BaseCommand):
             "/update_contact_information.html",
             "/vacancy_announcements.html",
             "/zoomgov.html",
-            "zoomgov_getting_ready.html",
-            "zoomgov_the_basics.html",
-            "zoomgov_zoomgov_proceedings.html",
+            "/zoomgov_getting_ready.html",
+            "/zoomgov_the_basics.html",
+            "/zoomgov_zoomgov_proceedings.html",
         ]
 
         for old_path in legacy_urls:

--- a/website/home/management/commands/create_pages.py
+++ b/website/home/management/commands/create_pages.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from django.conf import settings
 
 from home.management.commands.pages.about_the_court import (
     about_the_court_pages_to_initialize,
@@ -173,9 +174,15 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("All redirects have been initialized."))
 
         # Continue with existing initialization
-        for snippet_class in snippets_to_initialize:
-            snippet_instance = snippet_class()
-            snippet_instance.create()
+        if settings.IS_SITE_LIVE:
+            self.stdout.write(
+                "Skipping snippet creation. Snippets creation/recreation suppressed past site LIVE DATE."
+            )
+        else:
+            self.stdout.write("Creating snippets...")
+            for snippet_class in snippets_to_initialize:
+                snippet_instance = snippet_class()
+                snippet_instance.create()
 
         for page_class in pages_to_initialize:
             page_instance = page_class()

--- a/website/home/management/commands/create_pages.py
+++ b/website/home/management/commands/create_pages.py
@@ -198,9 +198,15 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("All pages have been updated."))
 
         # Initialize navigation last
-        nav_initializer = NavigationInitializer()
-        nav_initializer.create()
-        self.stdout.write(self.style.SUCCESS("Navigation has been initialized."))
+        if settings.IS_SITE_LIVE:
+            self.stdout.write(
+                "Skipping Navigation creation. Navigation menu creation/recreation suppressed past site LIVE DATE."
+            )
+        else:
+            self.stdout.write("Creating snippets...")
+            nav_initializer = NavigationInitializer()
+            nav_initializer.create()
+            self.stdout.write(self.style.SUCCESS("Navigation has been initialized."))
 
         # Initialize unlisted files
         unlisted_files_initializer = UnlistedFiles()

--- a/website/home/management/commands/create_pages.py
+++ b/website/home/management/commands/create_pages.py
@@ -174,7 +174,7 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("All redirects have been initialized."))
 
         # Continue with existing initialization
-        if settings.IS_SITE_LIVE:
+        if settings.SITE_IS_LIVE:
             self.stdout.write(
                 "Skipping snippet creation. Snippets creation/recreation suppressed past site LIVE DATE."
             )
@@ -198,15 +198,9 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("All pages have been updated."))
 
         # Initialize navigation last
-        if settings.IS_SITE_LIVE:
-            self.stdout.write(
-                "Skipping Navigation creation. Navigation menu creation/recreation suppressed past site LIVE DATE."
-            )
-        else:
-            self.stdout.write("Creating snippets...")
-            nav_initializer = NavigationInitializer()
-            nav_initializer.create()
-            self.stdout.write(self.style.SUCCESS("Navigation has been initialized."))
+        nav_initializer = NavigationInitializer()
+        nav_initializer.create()
+        self.stdout.write(self.style.SUCCESS("Navigation has been initialized."))
 
         # Initialize unlisted files
         unlisted_files_initializer = UnlistedFiles()

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_page.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_page.py
@@ -45,8 +45,8 @@ class DawsonPageInitializer(PageInitializer):
 
         existing_dawson_page = home_page.get_children().live().filter(slug=slug).first()
         if existing_dawson_page:
-            logger.info(f"- {title} page already exists. Updating cards...")
-            dawson_page = existing_dawson_page.specific
+            logger.info(f"- {title} page already exists.")
+            return
         else:
             dawson_page = DawsonPage(
                 title=title,

--- a/website/home/management/commands/pages/navigation.py
+++ b/website/home/management/commands/pages/navigation.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from home.management.commands.pages.page_initializer import PageInitializer
 from wagtail.models import Page
 from home.models import NavigationMenu
@@ -163,7 +164,14 @@ class NavigationInitializer(PageInitializer):
 
     def create(self):
         # Delete existing navigation menu if it exists
-        NavigationMenu.objects.all().delete()
+        if settings.SITE_IS_LIVE:
+            logger.info(
+                "Skipping Navigation creation. Navigation menu creation/recreation suppressed past site LIVE DATE."
+            )
+            return
+        else:
+            logger.info("Creating Navigation menu...")
+            NavigationMenu.objects.all().delete()
 
         # Create a single navigation menu
         menu = NavigationMenu.objects.create(menu_items=self.get_default_menu_items())


### PR DESCRIPTION
## Changes

- Prevent Snippets from getting updated post SITE golive date.
    - In sandbox and local, the site live date is set to: 2999/6/1, this enables developers to continue developing testing the snippet change.
    - In other environments, PROD and DEV, the site golive date is set in base settings as 2025/6/1.