### PR TITLE
Add ASPX and PNG to ignore 404 metric for alerts

### DIFF
--- a/infra/modules/app/alerts.tf
+++ b/infra/modules/app/alerts.tf
@@ -51,7 +51,7 @@ resource "aws_cloudwatch_metric_alarm" "error_404_alarm" {
   namespace           = "WebsiteErrors"
   period             = "3600"
   statistic          = "Sum"
-  threshold          = "5"
+  threshold          = "50"
   alarm_description  = "This metric monitors for 404 errors in the website logs"
   alarm_actions      = [aws_sns_topic.error_notifications.arn]
 

--- a/infra/modules/app/alerts.tf
+++ b/infra/modules/app/alerts.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "error_500_alarm" {
 
 resource "aws_cloudwatch_log_metric_filter" "error_404_filter" {
   name           = "${var.environment}-404-error-filter"
-  pattern        = "{ ($.status_code = 404) && ($.path != %.*\\.(xml|php|git)$%) }"
+  pattern        = "{ ($.status_code = 404) && ($.path != %.*\\.(xml|php|git|aspx|png)$%) }"
   log_group_name = aws_cloudwatch_log_group.ecs_log_group.name
 
   metric_transformation {


### PR DESCRIPTION
## Changes

- Added `aspx` and `png` to the ignore list in 404 metrics for alert generation.
- Increase the count from 5 / hr to 50 /hr.