### PR TITLE
Redeclare the SITE_IS_LIVE in all environments

### DIFF
--- a/website/app/settings/dev.py
+++ b/website/app/settings/dev.py
@@ -1,6 +1,7 @@
 from .base import *  # noqa: F403
 from .base import MIDDLEWARE  # noqa: F403
 import os
+from datetime import date
 
 os.environ.setdefault("DJANGO_SUPERUSER_PASSWORD", "ustcAdminPW!")
 
@@ -19,3 +20,5 @@ ENVIRONMENT = "dev"
 WAGTAILADMIN_BASE_URL = f"http://{ENVIRONMENT}-web.ustaxcourt.com"
 
 MIDDLEWARE = ["app.middleware.JSONExceptionMiddleware"] + MIDDLEWARE
+
+SITE_IS_LIVE = date.today() >= date(2025, 6, 1)

--- a/website/app/settings/production.py
+++ b/website/app/settings/production.py
@@ -1,5 +1,6 @@
 import os
 from .base import *  # noqa: F403
+from datetime import date
 
 DEBUG = False
 
@@ -13,3 +14,4 @@ BASE_URL = f'https://{os.getenv("DOMAIN_NAME")}'
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 WAGTAILADMIN_BASE_URL = "http://ustaxcourt.com"
+SITE_IS_LIVE = date.today() >= date(2025, 6, 1)


### PR DESCRIPTION
## Changes

- Redeclare `SITE_IS_LIVE` into development and production settings files.

## Test

Ran workflow in DEV, with: see run in: https://github.com/ustaxcourt/website-wagtail/actions/runs/15547837993/job/43772683544#step:11:252.

```shell
Skipping Navigation creation. Navigation menu creation/recreation suppressed past site LIVE DATE.

```