### PR TITLE
Bug: cloudfront caches "logged-in" version of page

### DIFF
--- a/infra/modules/app/cloudfront.tf
+++ b/infra/modules/app/cloudfront.tf
@@ -41,10 +41,13 @@ resource "aws_cloudfront_cache_policy" "custom_five_minute_app_cache" {
       cookie_behavior = "none"
     }
     headers_config {
-      header_behavior = "none"
+      header_behavior = "whitelist"
+      headers {
+        items = ["Host", "Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method"]
+      }
     }
     query_strings_config {
-      query_string_behavior = "none"
+      query_string_behavior = "all"
     }
     enable_accept_encoding_brotli = true
     enable_accept_encoding_gzip   = true

--- a/infra/modules/app/cloudfront.tf
+++ b/infra/modules/app/cloudfront.tf
@@ -54,6 +54,28 @@ resource "aws_cloudfront_cache_policy" "five_minute_cache" {
   }
 }
 
+resource "aws_cloudfront_cache_policy" "custom_app_cache" {
+  name        = "${var.environment}-custom_app_cache"
+  comment     = "Policy for custom application cache setting"
+  min_ttl     = 0    # 0 minutes
+  default_ttl = 300     # 5 minutes
+  max_ttl     = 300     # 5 minutes
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+    headers_config {
+      header_behavior = "none"
+    }
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+    enable_accept_encoding_brotli = true
+    enable_accept_encoding_gzip   = true
+  }
+}
+
 # Create origin request policy for dynamic content
 resource "aws_cloudfront_origin_request_policy" "dynamic_content" {
   name    = "${var.environment}-dynamic-content"
@@ -219,7 +241,7 @@ resource "aws_cloudfront_distribution" "app" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "app-origin"
 
-    cache_policy_id          = aws_cloudfront_cache_policy.five_minute_cache.id
+    cache_policy_id          = aws_cloudfront_cache_policy.custom_app_cache.id
     origin_request_policy_id = aws_cloudfront_origin_request_policy.dynamic_content.id
 
     viewer_protocol_policy = "redirect-to-https"

--- a/infra/modules/app/cloudfront.tf
+++ b/infra/modules/app/cloudfront.tf
@@ -28,35 +28,10 @@ data "aws_cloudfront_cache_policy" "caching_optimized" {
   name = "Managed-CachingOptimized"
 }
 
-# Create cache policy for 5-minute caching
-resource "aws_cloudfront_cache_policy" "five_minute_cache" {
-  name        = "${var.environment}-five-minute-cache"
-  comment     = "Policy for 5-minute caching of general content"
-  min_ttl     = 300     # 5 minutes
-  default_ttl = 300     # 5 minutes
-  max_ttl     = 300     # 5 minutes
-
-  parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-    headers_config {
-      header_behavior = "whitelist"
-      headers {
-        items = ["Host", "Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method"]
-      }
-    }
-    query_strings_config {
-      query_string_behavior = "all"
-    }
-    enable_accept_encoding_brotli = true
-    enable_accept_encoding_gzip   = true
-  }
-}
-
-resource "aws_cloudfront_cache_policy" "custom_app_cache" {
-  name        = "${var.environment}-custom_app_cache"
-  comment     = "Policy for custom application cache setting"
+# Create custom cache policy for 5-minute caching
+resource "aws_cloudfront_cache_policy" "custom_five_minute_app_cache" {
+  name        = "${var.environment}-custom-five-minute-app-cache"
+  comment     = "Policy for custom 5 minute application cache setting"
   min_ttl     = 0    # 0 minutes
   default_ttl = 300     # 5 minutes
   max_ttl     = 300     # 5 minutes
@@ -241,7 +216,7 @@ resource "aws_cloudfront_distribution" "app" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = "app-origin"
 
-    cache_policy_id          = aws_cloudfront_cache_policy.custom_app_cache.id
+    cache_policy_id          = aws_cloudfront_cache_policy.custom_five_minute_app_cache.id
     origin_request_policy_id = aws_cloudfront_origin_request_policy.dynamic_content.id
 
     viewer_protocol_policy = "redirect-to-https"

--- a/website/app/middleware.py
+++ b/website/app/middleware.py
@@ -42,8 +42,7 @@ class NoCacheForLoggedInUsersMiddleware:
             ] = "private, no-store, no-cache, must-revalidate, max-age=0"
             response["Pragma"] = "no-cache"
             response["Expires"] = "0"
-            response[
-                "X-Logged-In-User"
-            ] = "true"  # Custom header to help bypass CDN caching
-
+            response["X-Logged-In-User"] = "true"
+        else:
+            response["X-Logged-In-User"] = "false"
         return response

--- a/website/app/middleware.py
+++ b/website/app/middleware.py
@@ -43,4 +43,6 @@ class NoCacheForLoggedInUsersMiddleware:
             response["Pragma"] = "no-cache"
             response["Expires"] = "0"
             response["X-Logged-In-User"] = "true"
+        else:
+            response["Cache-Control"] = "max-age=300"
         return response

--- a/website/app/middleware.py
+++ b/website/app/middleware.py
@@ -43,6 +43,4 @@ class NoCacheForLoggedInUsersMiddleware:
             response["Pragma"] = "no-cache"
             response["Expires"] = "0"
             response["X-Logged-In-User"] = "true"
-        else:
-            response["X-Logged-In-User"] = "false"
         return response

--- a/website/app/middleware.py
+++ b/website/app/middleware.py
@@ -1,5 +1,7 @@
 import logging
 import traceback
+from django.utils.deprecation import MiddlewareMixin
+from django.utils.cache import patch_cache_control
 
 
 class JSONExceptionMiddleware:
@@ -27,3 +29,14 @@ class JSONExceptionMiddleware:
 
         # Let Django handle the response normally
         return None
+
+
+class NoCacheForLoggedInUsersMiddleware(MiddlewareMixin):
+    """
+    Prevents CloudFront from caching pages served to logged-in users.
+    """
+
+    def process_response(self, request, response):
+        if request.user.is_authenticated:
+            patch_cache_control(response, no_store=True, private=True)
+        return response

--- a/website/app/middleware.py
+++ b/website/app/middleware.py
@@ -42,5 +42,8 @@ class NoCacheForLoggedInUsersMiddleware:
             ] = "private, no-store, no-cache, must-revalidate, max-age=0"
             response["Pragma"] = "no-cache"
             response["Expires"] = "0"
+            response[
+                "X-Logged-In-User"
+            ] = "true"  # Custom header to help bypass CDN caching
 
         return response

--- a/website/app/settings/base.py
+++ b/website/app/settings/base.py
@@ -75,6 +75,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
+    "app.middleware.NoCacheForLoggedInUsersMiddleware",
 ]
 
 if os.getenv("CLOUDFRONT_DISTRIBUTION_ID"):

--- a/website/app/settings/base.py
+++ b/website/app/settings/base.py
@@ -70,12 +70,12 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "app.middleware.NoCacheForLoggedInUsersMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
-    "app.middleware.NoCacheForLoggedInUsersMiddleware",
 ]
 
 if os.getenv("CLOUDFRONT_DISTRIBUTION_ID"):


### PR DESCRIPTION
Adds middleware to detect logged-in users and set appropriate HTTP Cache-Control headers to prevent CloudFront from caching personalized content. This ensures that authenticated pages are not served to anonymous users due to CDN caching.

- Introduced `NoCacheForLoggedInUsersMiddleware`
- Sets 'Cache-Control: private, no-store' for authenticated requests
- Ensures compliance with CloudFront caching behavior
- Addresses bug where Wagtail user bar was visible to anonymous users

Fixes: caching bug affecting all AWS-based environments