### PR TITLE
Changes to SSO Login button caption/error message

### DIFF
--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -111,18 +111,17 @@
             {% if messages or form.errors %}
                 <ul>
                     {% if form.errors %}
-                        {% for error in form.non_field_errors %}
-                            <li class="debugerror">{{ error }}</li>
-                            {% if "You do not have permission to access the admin" in error %}
-                                <li class="error">
-                                    You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov">Website-adhoc@ustaxcourt.gov</a> to be added.
-                                </li>
-                            {% else %}
-                                <li class="error">{{ error }}</li>
-                            {% endif %}
-                        {% endfor %}
+                        {% for error in form.non_field_errors %}<li class="error">{{ error }}</li>{% endfor %}
                     {% endif %}
-                    {% for message in messages %}<li class="{{ message.tags }}">{{ message }}</li>{% endfor %}
+                    {% for message in messages %}
+                        {% if "You do not have permission to access the admin" in message %}
+                            <li class="{{ message.tags }}">
+                                You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov">Website-adhoc@ustaxcourt.gov</a> to be added.
+                            </li>
+                        {% else %}
+                            <li class="{{ message.tags }}">{{ message }}</li>
+                        {% endif %}
+                    {% endfor %}
                 </ul>
             {% endif %}
         </div>

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -112,6 +112,7 @@
                 <ul>
                     {% if form.errors %}
                         {% for error in form.non_field_errors %}
+                            {{error}}
                             {% if error.strip == "You do not have permission to access the admin" %}
                                 <li class="error">
                                     You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov">Website-adhoc@ustaxcourt.gov</a> to be added.
@@ -136,8 +137,8 @@
               method="post"
               autocomplete="off"
               novalidate>
-            {% csrf_token %}
             {% block login_form %}
+                {% csrf_token %}
                 {% url 'wagtailadmin_home' as home_url %}
                 <input type="hidden" name="next" value="{{ next|default:home_url }}" />
                 {% block fields %}

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -114,8 +114,9 @@
                         {% for error in form.non_field_errors %}<li class="error">{{ error }}</li>{% endfor %}
                     {% endif %}
                     {% for message in messages %}
+                        <pre>{{ message|debug }}</pre>
                         {{ message|safe }}
-                        {% if "You do not have permission to access the admin" in message %}
+                        {% if "You do not have permission to access the admin" in message.message %}
                             <li class="{{ message.tags }}">
                                 You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov">Website-adhoc@ustaxcourt.gov</a> to be added.
                             </li>

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -112,8 +112,8 @@
                 <ul>
                     {% if form.errors %}
                         {% for error in form.non_field_errors %}
-                            {{error}}
-                            {% if error.strip == "You do not have permission to access the admin" %}
+                            <li class="debugerror">{{ error }}</li>
+                            {% if "You do not have permission to access the admin" in error %}
                                 <li class="error">
                                     You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov">Website-adhoc@ustaxcourt.gov</a> to be added.
                                 </li>

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -114,11 +114,9 @@
                         {% for error in form.non_field_errors %}<li class="error">{{ error }}</li>{% endfor %}
                     {% endif %}
                     {% for message in messages %}
-                        <pre>{{ message|ppr }}</pre>
-                        {{ message|safe }}
                         {% if "You do not have permission to access the admin" in message.message %}
                             <li class="{{ message.tags }}">
-                                You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov">Website-adhoc@ustaxcourt.gov</a> to be added.
+                                You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov" title="email: website-adhoc@ustaxcourt.gov" style="color: rgb(0, 94, 162);">Website-adhoc@ustaxcourt.gov</a> to be added.
                             </li>
                         {% else %}
                             <li class="{{ message.tags }}">{{ message }}</li>

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -111,7 +111,15 @@
             {% if messages or form.errors %}
                 <ul>
                     {% if form.errors %}
-                        {% for error in form.non_field_errors %}<li class="error">{{ error }}</li>{% endfor %}
+                        {% for error in form.non_field_errors %}
+                            {% if error.strip == "You do not have permission to access the admin" %}
+                                <li class="error">
+                                    You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov">Website-adhoc@ustaxcourt.gov</a> to be added.
+                                </li>
+                            {% else %}
+                                <li class="error">{{ error }}</li>
+                            {% endif %}
+                        {% endfor %}
                     {% endif %}
                     {% for message in messages %}<li class="{{ message.tags }}">{{ message }}</li>{% endfor %}
                 </ul>

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load i18n wagtailadmin_tags custom_tags %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}
     {% trans "Sign in" %}
 {% endblock %}

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -119,7 +119,7 @@
         </div>
         {% block above_login %}{% endblock %}
         <a href="{% url "social:begin" "azuread-tenant-oauth2" %}"
-           class="azure-login">Login with Azure AD</a>
+           class="azure-login">Login with Court SSO credentials</a>
         <div class="divider">
             <span>or</span>
         </div>
@@ -128,8 +128,8 @@
               method="post"
               autocomplete="off"
               novalidate>
+            {% csrf_token %}
             {% block login_form %}
-                {% csrf_token %}
                 {% url 'wagtailadmin_home' as home_url %}
                 <input type="hidden" name="next" value="{{ next|default:home_url }}" />
                 {% block fields %}

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags custom_tags %}
 {% block titletag %}
     {% trans "Sign in" %}
 {% endblock %}
@@ -114,7 +114,7 @@
                         {% for error in form.non_field_errors %}<li class="error">{{ error }}</li>{% endfor %}
                     {% endif %}
                     {% for message in messages %}
-                        <pre>{{ message|debug }}</pre>
+                        <pre>{{ message|ppr }}</pre>
                         {{ message|safe }}
                         {% if "You do not have permission to access the admin" in message.message %}
                             <li class="{{ message.tags }}">

--- a/website/home/templates/wagtailadmin/login.html
+++ b/website/home/templates/wagtailadmin/login.html
@@ -114,6 +114,7 @@
                         {% for error in form.non_field_errors %}<li class="error">{{ error }}</li>{% endfor %}
                     {% endif %}
                     {% for message in messages %}
+                        {{ message|safe }}
                         {% if "You do not have permission to access the admin" in message %}
                             <li class="{{ message.tags }}">
                                 You need permission to access the administrative section of this website. Please contact Web Apps Team <a href="mailto:website-adhoc@ustaxcourt.gov">Website-adhoc@ustaxcourt.gov</a> to be added.

--- a/website/home/templatetags/custom_tags.py
+++ b/website/home/templatetags/custom_tags.py
@@ -1,5 +1,4 @@
 from django import template
-from pprint import pformat
 import re
 
 register = template.Library()
@@ -23,12 +22,3 @@ def judge_display_name(judge):
         role = judge.roles.first()
         return f"{role.role_name} {judge.display_name}"
     return f"{judge.title} {judge.display_name}"
-
-
-@register.filter
-def ppr(value):
-    """
-    A filter to pretty-print a variable.
-    Usage: {{ my_variable|ppr }}
-    """
-    return pformat(value)

--- a/website/home/templatetags/custom_tags.py
+++ b/website/home/templatetags/custom_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from pprint import pformat
 import re
 
 register = template.Library()
@@ -22,3 +23,12 @@ def judge_display_name(judge):
         role = judge.roles.first()
         return f"{role.role_name} {judge.display_name}"
     return f"{judge.title} {judge.display_name}"
+
+
+@register.filter
+def ppr(value):
+    """
+    A filter to pretty-print a variable.
+    Usage: {{ my_variable|ppr }}
+    """
+    return pformat(value)


### PR DESCRIPTION
## Changes

- Rename "Admin" login button caption to: "Login with Court SSO credentials"
- Provide detailed error message when the user is not configured to access Admin.

## Test

To test the functionality/error message.

- Setup user:
    - If it is a new user, do not configure anything beforehand.
    - Login as "Admin" and delete/remove the SSO user already configured.
- Access `/admin` and select "Login with Court SSO credentials".

<img width="515" alt="image" src="https://github.com/user-attachments/assets/c04d49e4-1431-4f4b-9b80-f9fe6be5e0a8" />
