### PR TITLE
Fix DAWSON text to normal font

### DIFF
--- a/website/home/templates/home/dawson_page.html
+++ b/website/home/templates/home/dawson_page.html
@@ -84,13 +84,6 @@
             flex: 1;
         }
 
-        #dawson-page .dedication .dedication-text .dedication-text-normal p {
-            font-size: 17px;
-            line-height: 24px;
-            font-family: var(--body-font);
-            font-weight: 400;
-        }
-
         #dawson-page .usa-card-group.fancy-card-group {
             margin: 0;
             padding: 0;
@@ -204,7 +197,7 @@
                             {% endif %}
                             <div class="dedication-text">
                                 <h2>{{ dedication.title }}</h2>
-                                <div class="dedication-text-normal">{{ dedication.paragraph_text | richtext }}</div>
+                                {{ dedication.paragraph_text | richtext }}
                             </div>
                         </div>
                     {% endfor %}

--- a/website/home/templates/home/dawson_page.html
+++ b/website/home/templates/home/dawson_page.html
@@ -91,6 +91,13 @@
             font-weight: 700;
         }
 
+        #dawson-page .dedication .dedication-text .dedication-text-normal {
+            font-size: 17px;
+            line-height: 24px;
+            font-family: var(--body-font);
+            font-weight: 400;
+        }
+
         #dawson-page .usa-card-group.fancy-card-group {
             margin: 0;
             padding: 0;
@@ -204,7 +211,7 @@
                             {% endif %}
                             <div class="dedication-text">
                                 <h2>{{ dedication.title }}</h2>
-                                {{ dedication.paragraph_text | richtext }}
+                                <p class="dedication-text-normal">{{ dedication.paragraph_text | richtext }}</p>
                             </div>
                         </div>
                     {% endfor %}

--- a/website/home/templates/home/dawson_page.html
+++ b/website/home/templates/home/dawson_page.html
@@ -197,7 +197,7 @@
                             {% endif %}
                             <div class="dedication-text">
                                 <h2>{{ dedication.title }}</h2>
-                                {{ dedication.paragraph_text | richtext }}
+                                <div>{{ dedication.paragraph_text | richtext }}</div>
                             </div>
                         </div>
                     {% endfor %}

--- a/website/home/templates/home/dawson_page.html
+++ b/website/home/templates/home/dawson_page.html
@@ -84,14 +84,7 @@
             flex: 1;
         }
 
-        #dawson-page .dedication .dedication-text p {
-            font-size: 24px;
-            line-height: 32px;
-            font-family: var(--heading-font);
-            font-weight: 700;
-        }
-
-        #dawson-page .dedication .dedication-text .dedication-text-normal {
+        #dawson-page .dedication .dedication-text .dedication-text-normal p {
             font-size: 17px;
             line-height: 24px;
             font-family: var(--body-font);
@@ -211,7 +204,7 @@
                             {% endif %}
                             <div class="dedication-text">
                                 <h2>{{ dedication.title }}</h2>
-                                <p class="dedication-text-normal">{{ dedication.paragraph_text | richtext }}</p>
+                                <div class="dedication-text-normal">{{ dedication.paragraph_text | richtext }}</div>
                             </div>
                         </div>
                     {% endfor %}


### PR DESCRIPTION
## Changes

- Enclose the text on DAWSON photo dedication section with `<div></div>`
- Ensure further edits don't block, scramble the display.

## Test
Deployed in sandbox: https://sappachi-sandbox-web.ustaxcourt.gov/dawson/

And made an update and published. The changes with display look good and holds as expected.