### PR TITLE
Add 'insert entry above' functionality to HomePage admin interface

### DIFF
--- a/website/home/management/commands/pages/home_page.py
+++ b/website/home/management/commands/pages/home_page.py
@@ -101,6 +101,7 @@ class HomePageInitializer(PageInitializer):
             start_date=datetime(2024, 12, 31, 6, 0),  # Example: 6 AM EST
             end_date=datetime(2025, 1, 1, 23, 59),  # Example: 11.59 PM EST
             persist_to_press_releases=True,
+            sort_order=0,
         )
         HomePageEntry.objects.create(
             homepage=homepage,
@@ -111,6 +112,7 @@ class HomePageInitializer(PageInitializer):
             start_date=datetime(2024, 12, 1, 6, 0),
             end_date=datetime(2024, 12, 25, 23, 59),
             persist_to_press_releases=True,
+            sort_order=1,
         )
         HomePageEntry.objects.create(
             homepage=homepage,
@@ -121,6 +123,7 @@ class HomePageInitializer(PageInitializer):
             start_date=datetime(2025, 4, 14, 6, 0),
             end_date=None,
             persist_to_press_releases=True,
+            sort_order=2,
         )
         HomePageEntry.objects.create(
             homepage=homepage,
@@ -131,6 +134,7 @@ class HomePageInitializer(PageInitializer):
             start_date=datetime(2025, 4, 29, 6, 0),
             end_date=None,
             persist_to_press_releases=True,
+            sort_order=3,
         )
         HomePageEntry.objects.create(
             homepage=homepage,
@@ -141,6 +145,7 @@ class HomePageInitializer(PageInitializer):
             start_date=datetime(2025, 4, 14, 6, 0),
             end_date=None,
             persist_to_press_releases=True,
+            sort_order=4,
         )
         HomePageEntry.objects.create(
             homepage=homepage,
@@ -151,6 +156,7 @@ class HomePageInitializer(PageInitializer):
             start_date=datetime(2025, 4, 7, 6, 0),
             end_date=datetime(2025, 5, 5, 23, 59),
             persist_to_press_releases=True,
+            sort_order=5,
         )
         HomePageEntry.objects.create(
             homepage=homepage,
@@ -169,6 +175,7 @@ class HomePageInitializer(PageInitializer):
             start_date=None,
             end_date=None,
             persist_to_press_releases=True,
+            sort_order=6,
         )
 
         logger.info("Successfully created the new Home page.")
@@ -208,6 +215,7 @@ class HomePageInitializer(PageInitializer):
                 "start_date": datetime(2025, 5, 5, 6, 0),
                 "end_date": None,
                 "persist_to_press_releases": True,
+                "sort_order": 7,
             },
             # Add more entries as needed
         ]
@@ -224,6 +232,7 @@ class HomePageInitializer(PageInitializer):
                     start_date=entry_data["start_date"],
                     end_date=entry_data["end_date"],
                     persist_to_press_releases=entry_data["persist_to_press_releases"],
+                    sort_order=entry_data["sort_order"],
                 )
                 logger.info(f"{entry_data['title']} entry created successfully.")
             else:

--- a/website/home/models/custom_blocks/add_entry_above_view.py
+++ b/website/home/models/custom_blocks/add_entry_above_view.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 
-from ..pages.home_page import HomePageEntry
+from home.models.pages.home_page import HomePageEntry
 from django.urls import reverse
 from wagtail.models import Page
 from django.http import HttpResponseRedirect

--- a/website/home/models/custom_blocks/add_entry_above_view.py
+++ b/website/home/models/custom_blocks/add_entry_above_view.py
@@ -1,0 +1,41 @@
+from django.contrib import messages
+
+from ..pages.home_page import HomePageEntry
+from django.urls import reverse
+from wagtail.models import Page
+from django.http import HttpResponseRedirect
+
+
+def add_entry_above_view(request, sort_order, page_id):
+    try:
+        page = Page.objects.get(id=page_id)
+
+        # If the page has unpublished changes, get the latest revision.
+        # Otherwise, use the live, specific page.
+        if page.has_unpublished_changes:
+            home_page = page.get_latest_revision_as_object()
+        else:
+            home_page = page.specific
+
+        target_entry = home_page.entries.get(sort_order=sort_order)
+        target_entry.add_entry_above_me(sort_order=sort_order, request=request)
+
+        messages.success(request, "New entry added above the selected entry.")
+
+        # Redirect back to the editor
+        url = reverse("wagtailadmin_pages:edit", args=(home_page.id,))
+        return HttpResponseRedirect(f"{url}#inline_child_entries-{sort_order}")
+
+    except Page.DoesNotExist:
+        messages.error(request, "The page was not found.")
+        return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))
+    except HomePageEntry.DoesNotExist:
+        messages.error(
+            request,
+            f"Could not find an entry with sort_order={sort_order} on this page.",
+        )
+        # Redirect back to the editor, even on error
+        if "page" in locals():
+            url = reverse("wagtailadmin_pages:edit", args=(page.id,))
+            return HttpResponseRedirect(url)
+        return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/admin/"))

--- a/website/home/models/custom_blocks/add_entry_custom_button.py
+++ b/website/home/models/custom_blocks/add_entry_custom_button.py
@@ -1,0 +1,45 @@
+from django.utils.safestring import mark_safe
+from wagtail.admin.panels import Panel
+from django.urls import reverse
+
+
+class AddEntryButton(Panel):
+    def __init__(self, button_text="Run Step Action", **kwargs):
+        super().__init__(**kwargs)
+        self.button_text = button_text
+
+    def clone(self):
+        return self.__class__(button_text=self.button_text)
+
+    class BoundPanel(Panel.BoundPanel):
+        def __init__(self, panel, instance=None, form=None, request=None, prefix=None):
+            super().__init__(
+                panel=panel,
+                instance=instance,
+                form=form,
+                request=request,
+                prefix=prefix,
+            )
+            self.button_text = panel.button_text
+
+        def render_html(self, parent_context=None):
+            # Get the entry ID from the parent instance if available
+            sort_order = getattr(self.instance, "sort_order", None)
+            page_id = self.instance.homepage.id
+
+            button_html = f"""
+                <div style="margin-top:10px;">
+                    <button type="button" class="step-action-btn">{self.button_text}</button>
+                </div>
+            """
+
+            if sort_order is not None and page_id is not None:
+                # If we have an entry ID and it's part of a homepage, we can create a proper link
+                url = reverse("add_entry_above_view", args=[page_id, sort_order])
+                button_html = f"""
+                    <div style="margin-top:10px; margin-bottom:20px;">
+                        <a href="{url}" class="button button-small button-secondary">{self.button_text}</a>
+                    </div>
+                """
+
+            return mark_safe(button_html)

--- a/website/home/models/pages/home_page.py
+++ b/website/home/models/pages/home_page.py
@@ -1,10 +1,13 @@
 from django.db import models
+from django.contrib import messages
+
 from wagtail.admin.panels import FieldPanel, InlinePanel
 from wagtail.fields import RichTextField
 from wagtail.models import Page, Orderable, ParentalKey
 from wagtail.search import index
 
 from django.utils import timezone
+from ..custom_blocks.add_entry_custom_button import AddEntryButton
 
 
 class HomePage(Page):
@@ -57,7 +60,40 @@ class HomePageEntry(Orderable):
     def is_expired(self):
         return self.end_date and self.end_date < timezone.now()
 
+    def add_entry_above_me(self, sort_order, request):
+        try:
+            parent = self.homepage.get_latest_revision_as_object()
+
+            new_entry = HomePageEntry(
+                homepage=parent,
+                title="Insert title ...",
+                body="",
+                start_date=None,
+                end_date=None,
+                persist_to_press_releases=True,
+            )
+
+            entries = list(parent.entries.order_by("sort_order"))
+            current_index = sort_order
+
+            if current_index > -1:
+                for i in range(len(entries) - 1, current_index - 1, -1):
+                    entry = parent.entries.get(sort_order=i)
+                    parent.entries.remove(entry)
+                    entry.sort_order += 1
+                    parent.entries.add(entry)
+
+                new_entry.sort_order = current_index
+                parent.entries.add(new_entry)
+                parent.save_revision(user=request.user)
+
+            return new_entry
+        except Exception as e:
+            messages.error(request, f"Error adding entry above: {str(e)}")
+            return None
+
     panels = [
+        AddEntryButton(button_text="Add Entry Above"),
         FieldPanel("title"),
         FieldPanel("body"),
         FieldPanel("start_date"),

--- a/website/home/models/pages/home_page.py
+++ b/website/home/models/pages/home_page.py
@@ -7,7 +7,7 @@ from wagtail.models import Page, Orderable, ParentalKey
 from wagtail.search import index
 
 from django.utils import timezone
-from ..custom_blocks.add_entry_custom_button import AddEntryButton
+from home.models.custom_blocks.add_entry_custom_button import AddEntryButton
 
 
 class HomePage(Page):

--- a/website/home/templates/wagtailadmin/base.html
+++ b/website/home/templates/wagtailadmin/base.html
@@ -5,6 +5,9 @@
         .pagination {
             margin-bottom: 3rem;
         }
+        #id_entries-ADD {
+            display: none !important;
+        }
     </style>
 {% endblock %}
 {% block extra_js %}

--- a/website/home/wagtail_hooks.py
+++ b/website/home/wagtail_hooks.py
@@ -5,10 +5,12 @@ from wagtail.models import Page
 from .models import NavigationMenu, JudgeRole
 from .models.snippets.judges import RESTRICTED_ROLES
 from django.shortcuts import redirect
-from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
+from django.urls import path, reverse
+from .models.custom_blocks.add_entry_above_view import add_entry_above_view
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -140,3 +142,14 @@ def purge_cache_for_snippet_related_pages(request, instance):
             logger.info(f"Purged frontend cache for page: {page.url_path}")
         except Exception as e:
             logger.error(f"Error purging cache for page {page.id}: {e}")
+
+
+@hooks.register("register_admin_urls")
+def register_add_entry_above_url():
+    return [
+        path(
+            "add_entry_above/<int:page_id>/<int:sort_order>/",
+            add_entry_above_view,
+            name="add_entry_above_view",
+        ),
+    ]

--- a/website/home/wagtail_hooks.py
+++ b/website/home/wagtail_hooks.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from django.urls import path, reverse
-from .models.custom_blocks.add_entry_above_view import add_entry_above_view
+from home.models.custom_blocks.add_entry_above_view import add_entry_above_view
 
 import logging
 

--- a/website/home/wagtail_hooks.py
+++ b/website/home/wagtail_hooks.py
@@ -2,8 +2,8 @@ from django.contrib import messages
 from django.conf import settings
 from wagtail.contrib.frontend_cache.utils import purge_page_from_cache
 from wagtail.models import Page
-from .models import NavigationMenu, JudgeRole
-from .models.snippets.judges import RESTRICTED_ROLES
+from home.models import NavigationMenu, JudgeRole
+from home.models.snippets.judges import RESTRICTED_ROLES
 from django.shortcuts import redirect
 from django.utils.translation import gettext_lazy as _
 from wagtail import hooks


### PR DESCRIPTION
## Changes

- Added "Add Entry Above" button to HomePage entries in Wagtail admin
- Allows editors to insert new entries at specific positions
- Includes proper sort_order management for existing entries
- Fixed sort_order initialization in page creation commands