### PR TITLE
Distinguish the admin UX in the lower environments from prod-web

### DIFF
--- a/website/app/context_processors.py
+++ b/website/app/context_processors.py
@@ -3,3 +3,7 @@ from django.conf import settings
 
 def build_info(request):
     return {"build_sha": settings.GITHUB_SHA[:6]}
+
+
+def get_environment(request):
+    return {"environment": getattr(settings, "ENVIRONMENT", "production")}

--- a/website/app/settings/base.py
+++ b/website/app/settings/base.py
@@ -110,6 +110,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "wagtail.contrib.settings.context_processors.settings",
                 "app.context_processors.build_info",
+                "app.context_processors.get_environment",
                 "social_django.context_processors.backends",
                 "social_django.context_processors.login_redirect",
             ],
@@ -315,9 +316,9 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Add this setting to store your GA tracking ID
 GOOGLE_ANALYTICS_ID = "G-3T6ZS0FHZ8"
 
-ENVIRONMENT = "dev"
+ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
 
-BASE_URL = "http://127.0.0.1:8000"
+BASE_URL = os.getenv("BASE_URL", "http://127.0.0.1:8000")
 
 # GitHub SHA for build version
 GITHUB_SHA = os.getenv("GITHUB_SHA")

--- a/website/app/templates/base.html
+++ b/website/app/templates/base.html
@@ -3,7 +3,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        {% get_enviroment as environment %}
+        {% get_environment as environment %}
         {% if environment != "production" %}<meta name="robots" content="noindex">{% endif %}
         <title>
             {% block title %}
@@ -103,7 +103,7 @@
     </head>
     <body class="{% block body_class %}  {% endblock %}">
         {% include 'banner.html' %}
-        {% get_enviroment as environment %}
+        {% get_environment as environment %}
         {% if environment != "production" %}
             {% include 'alert_banner.html' %}
         {% endif %}

--- a/website/home/templates/wagtailadmin/base.html
+++ b/website/home/templates/wagtailadmin/base.html
@@ -5,8 +5,27 @@
         .pagination {
             margin-bottom: 3rem;
         }
+        .admin-env-banner {
+            background-color: #FAA500;
+            color: #020103;
+            padding: 10px 15px;
+            font-weight: bold;
+            text-align: center;
+            font-size: 15px;
+            border-bottom: 1px solid #ffeeba;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
     </style>
 {% endblock %}
+
+{% block body_class %}
+    {{ block.super }}
+    {% if environment != "production" %}
+    {% endif %}
+{% endblock %}
+
 {% block extra_js %}
     {{ block.super }}
     <script>
@@ -38,6 +57,18 @@
 
             // Add the button to the admin dashboard
             document.body.appendChild(scrollButton);
+
+            {% if environment != "production" %}
+            const banner = document.createElement("div");
+            banner.className = "admin-env-banner";
+            banner.innerHTML = `
+                    <span> ⚠️ You are in the {{ environment|upper }} environment — changes here will not affect production.</span>
+                `;
+            const header = document.querySelector(".wagtail-logo") || document.querySelector("header");
+            if (header && header.parentNode) {
+                header.parentNode.insertBefore(banner, header.nextSibling);
+            }
+            {% endif %}
         });
     </script>
 {% endblock %}

--- a/website/home/templatetags/env_tags.py
+++ b/website/home/templatetags/env_tags.py
@@ -6,5 +6,5 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def get_enviroment(context):
+def get_environment(context):
     return settings.ENVIRONMENT


### PR DESCRIPTION

- Adds a visual banner to Wagtail admin when the environment is not production.
- Helps prevent accidental edits in dev or staging environments by providing
- a clear warning at the top of every admin page.
- Fixed typo **get_enviroment** to **get_environment**


<img width="1724" alt="Screenshot 2025-06-27 at 3 45 21 PM" src="https://github.com/user-attachments/assets/26595d67-a069-4a7b-a6fb-18c145d02375" />
<img width="1727" alt="Screenshot 2025-06-27 at 3 45 30 PM" src="https://github.com/user-attachments/assets/7305eefa-13a9-4c7c-b500-f40f5a8ab666" />
<img width="1728" alt="Screenshot 2025-06-27 at 3 45 40 PM" src="https://github.com/user-attachments/assets/5311f79c-cffc-4f28-9dad-09f9a9b1a52c" />
