### PR TITLE
Search: Add meta description logic

### DIFF
--- a/website/search/templates/search/search.html
+++ b/website/search/templates/search/search.html
@@ -263,7 +263,7 @@
                             </h2>
                         {% endif %}
                         {% if result.search_snippet %}
-                        <div class="desc">{{ result.search_snippet|striptags|truncatechars:200 }}</div>
+                            <div class="desc">{{ result.search_snippet|striptags|truncatechars:200 }}</div>
                         {% endif %}
                     </li>
                 {% endfor %}

--- a/website/search/templates/search/search.html
+++ b/website/search/templates/search/search.html
@@ -263,13 +263,7 @@
                             </h2>
                         {% endif %}
                         {% if result.search_snippet %}
-                            <div class="desc">{{ result.search_snippet|striptags|truncatechars:200 }}</div>
-                        {% elif result.search_description and result.search_description != result.title %}
-                            <div class="desc">{{ result.search_description|striptags|truncatechars:200 }}</div>
-                        {% elif result.body %}
-                            <div class="desc">{{ result.body|striptags|truncatechars:200 }}</div>
-                        {% elif result.intro %}
-                            <div class="desc">{{ result.intro|striptags|truncatechars:200 }}</div>
+                        <div class="desc">{{ result.search_snippet|striptags|truncatechars:200 }}</div>
                         {% endif %}
                     </li>
                 {% endfor %}

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -62,11 +62,16 @@ def extract_text_from_streamfield(stream_value, max_length=300):
 
 def get_search_snippet(page):
     """
-    Get a search snippet from a page's content.
+    Get a search snippet from a page's content, prioritizing search_description.
     """
 
     # Try getting the specific version of the page
     specific_page = page.specific
+
+    # 1️⃣ Prioritize the meta description if present
+    if getattr(specific_page, "search_description", None):
+        return strip_tags(specific_page.search_description)
+    # Fallback logic
 
     if hasattr(specific_page, "body"):
         body = getattr(specific_page, "body")


### PR DESCRIPTION
- Prioritize meta descriptions and promoted results in search output
- Ensured promoted results override organic results and display their own descriptions
- Refactored search.html to rely on computed `search_snippet` only

With meta description 
![Screenshot 2025-07-01 at 1 23 55 PM](https://github.com/user-attachments/assets/3260bffd-21f6-43c0-a8f6-cce1b8626c8f)


Without Meta description: fall back to logic (body)
![Screenshot 2025-07-01 at 1 23 37 PM](https://github.com/user-attachments/assets/093b6f61-5a98-46ac-8c28-8dab338516b2)

