### PR TITLE
Refactor create redirect to be callable with input parameters

### DIFF
--- a/website/home/management/commands/create_pages.py
+++ b/website/home/management/commands/create_pages.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # Initialize redirects first
         redirect_initializer = RedirectInitializer()
-        redirect_initializer.create_redirect()
+        redirect_initializer.create_redirects()
 
         self.stdout.write(self.style.SUCCESS("All redirects have been initialized."))
 

--- a/website/home/management/commands/create_pages.py
+++ b/website/home/management/commands/create_pages.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # Initialize redirects first
         redirect_initializer = RedirectInitializer()
-        redirect_initializer.create_redirects()
+        redirect_initializer.create_redirect()
 
         self.stdout.write(self.style.SUCCESS("All redirects have been initialized."))
 

--- a/website/home/management/commands/redirects/redirect_initializer.py
+++ b/website/home/management/commands/redirects/redirect_initializer.py
@@ -166,7 +166,7 @@ class RedirectInitializer:
         except ValidationError as e:
             logger.info(f"Error creating redirect for '{old_path}': {e}")
 
-    def create_redirects(self):
+    def create_redirect(self):
         """
         Create all redirects from the REDIRECTS configuration
         """

--- a/website/home/management/commands/redirects/redirect_initializer.py
+++ b/website/home/management/commands/redirects/redirect_initializer.py
@@ -45,7 +45,18 @@ REDIRECTS = [
         "new_path": "/press-releases/archives",
         "is_permanent": True,
     },
+    {
+        "old_path": "/dawson_faqs.html",
+        "new_path": "/dawson-faqs-basics",
+        "is_permanent": True,
+    },
+    {
+        "old_path": "/tou.html",
+        "new_path": "/dawson-tou",
+        "is_permanent": True,
+    },
 ]
+
 
 LEGACY_URLS = [
     "/administrative_orders.html",
@@ -62,7 +73,6 @@ LEGACY_URLS = [
     "/dawson.html",
     "/dawson_account_petitioner.html",
     "/dawson_account_practitioner.html",
-    "/dawson_faqs.html",
     "/dawson_faqs_account_management.html",
     "/dawson_faqs_basics.html",
     "/dawson_faqs_case_management.html",
@@ -133,30 +143,36 @@ class RedirectInitializer:
     def __init__(self):
         self.logger = logger
 
-    def create_redirect(self):
+    def create(self, old_path, new_path, is_permanent=True):
         """
-        Create a redirect if it doesn't already exist
+        Create a single redirect if it doesn't already exist
 
         Args:
             old_path (str): The path to redirect from
             new_path (str): The path to redirect to
             is_permanent (bool): Whether this is a permanent (301) or temporary (302) redirect
         """
+        if Redirect.objects.filter(old_path=old_path).exists():
+            logger.info(f"- Redirect from '{old_path}' already exists.")
+            return
+
+        try:
+            Redirect.objects.create(
+                old_path=old_path,
+                redirect_link=new_path,
+                is_permanent=is_permanent,
+            )
+            logger.info(f"Created redirect from '{old_path}' → '{new_path}'")
+        except ValidationError as e:
+            logger.info(f"Error creating redirect for '{old_path}': {e}")
+
+    def create_redirects(self):
+        """
+        Create all redirects from the REDIRECTS configuration
+        """
         logger.info("Initializing redirects...")
         for redirect in REDIRECTS:
             old_path = redirect["old_path"]
             new_path = redirect["new_path"]
             is_permanent = redirect["is_permanent"]
-            if Redirect.objects.filter(old_path=old_path).exists():
-                logger.info(f"- Redirect from '{old_path}' already exists.")
-                continue
-            else:
-                try:
-                    Redirect.objects.create(
-                        old_path=old_path,
-                        redirect_link=new_path,
-                        is_permanent=is_permanent,
-                    )
-                    logger.info(f"Created redirect from '{old_path}' → '{new_path}'")
-                except ValidationError as e:
-                    logger.info(f"Error creating redirect for '{old_path}': {e}")
+            self.create(old_path, new_path, is_permanent)

--- a/website/home/management/commands/redirects/redirect_initializer.py
+++ b/website/home/management/commands/redirects/redirect_initializer.py
@@ -153,7 +153,7 @@ class RedirectInitializer:
             is_permanent (bool): Whether this is a permanent (301) or temporary (302) redirect
         """
         if Redirect.objects.filter(old_path=old_path).exists():
-            logger.info(f"- Redirect from '{old_path}' already exists.")
+            self.logger.info(f"- Redirect from '{old_path}' already exists.")
             return
 
         try:
@@ -162,15 +162,15 @@ class RedirectInitializer:
                 redirect_link=new_path,
                 is_permanent=is_permanent,
             )
-            logger.info(f"Created redirect from '{old_path}' → '{new_path}'")
+            self.logger.info(f"Created redirect from '{old_path}' → '{new_path}'")
         except ValidationError as e:
-            logger.info(f"Error creating redirect for '{old_path}': {e}")
+            self.logger.info(f"Error creating redirect for '{old_path}': {e}")
 
     def create_redirect(self):
         """
         Create all redirects from the REDIRECTS configuration
         """
-        logger.info("Initializing redirects...")
+        self.logger.info("Initializing redirects...")
         for redirect in REDIRECTS:
             old_path = redirect["old_path"]
             new_path = redirect["new_path"]

--- a/website/tests/home/management/commands/test_redirects.py
+++ b/website/tests/home/management/commands/test_redirects.py
@@ -17,7 +17,7 @@ class TestRedirectBehavior(TestCase):
 
         # Ensure redirects are created before testing
         initializer = RedirectInitializer()
-        initializer.create_redirects()
+        initializer.create_redirect()
 
     def _test_redirect(self, old_path, expected_new_path):
         """Helper method to test redirect behavior."""

--- a/website/tests/home/management/commands/test_redirects.py
+++ b/website/tests/home/management/commands/test_redirects.py
@@ -1,0 +1,149 @@
+from django.test import TestCase, RequestFactory
+from django.http import HttpResponseNotFound
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.contrib.redirects.middleware import RedirectMiddleware
+
+from home.management.commands.redirects.redirect_initializer import (
+    RedirectInitializer,
+    REDIRECTS,
+)
+
+
+class TestRedirectBehavior(TestCase):
+    """Black box tests to verify that configured redirects work correctly."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+        # Ensure redirects are created before testing
+        initializer = RedirectInitializer()
+        initializer.create_redirects()
+
+    def _test_redirect(self, old_path, expected_new_path):
+        """Helper method to test redirect behavior."""
+        # First check if the redirect exists in the database
+        redirect = Redirect.objects.filter(old_path=old_path).first()
+        self.assertIsNotNone(
+            redirect, f"Redirect should exist in database for {old_path}"
+        )
+        self.assertEqual(redirect.redirect_link, expected_new_path)
+
+        # Test the redirect middleware directly
+        request = self.factory.get(old_path)
+        middleware = RedirectMiddleware(lambda _: None)
+
+        # Simulate a 404 response for the middleware to process
+        mock_response = HttpResponseNotFound()
+
+        # Process the request through the middleware
+        response = middleware.process_response(request, mock_response)
+
+        # Check that the middleware returns a redirect
+        self.assertEqual(response.status_code, 301)  # Permanent redirect
+        self.assertEqual(response.url, expected_new_path)
+
+    def test_vacancy_announcements_redirect(self):
+        """Test that /vacancy_announcements redirects to /employment/vacancy-announcements."""
+        self._test_redirect(
+            "/vacancy_announcements", "/employment/vacancy-announcements"
+        )
+
+    def test_vacancy_announcements_html_redirect(self):
+        """Test that /vacancy_announcements.html redirects to /employment/vacancy-announcements."""
+        self._test_redirect(
+            "/vacancy_announcements.html", "/employment/vacancy-announcements"
+        )
+
+    def test_judges_recruiting_redirect(self):
+        """Test that /judges_recruiting.html redirects to /employment/judges-recruiting."""
+        self._test_redirect("/judges_recruiting.html", "/employment/judges-recruiting")
+
+    def test_taxpayers_before_redirect(self):
+        """Test that /taxpayers_before.html redirects to /petitioners-before."""
+        self._test_redirect("/taxpayers_before.html", "/petitioners-before")
+
+    def test_internship_programs_redirect(self):
+        """Test that /internship_programs.html redirects to /employment/internship-programs."""
+        self._test_redirect(
+            "/internship_programs.html", "/employment/internship-programs"
+        )
+
+    def test_law_clerk_program_redirect(self):
+        """Test that /law_clerk_program.html redirects to /employment/law-clerk-program."""
+        self._test_redirect("/law_clerk_program.html", "/employment/law-clerk-program")
+
+    def test_index_html_redirect(self):
+        """Test that /index.html redirects to /."""
+        self._test_redirect("/index.html", "/")
+
+    def test_press_release_archives_redirect(self):
+        """Test that /press_release_archives.html redirects to /press-releases/archives."""
+        self._test_redirect("/press_release_archives.html", "/press-releases/archives")
+
+    def test_dawson_faqs_redirect(self):
+        """Test that /dawson_faqs.html redirects to /dawson-faqs-basics."""
+        self._test_redirect("/dawson_faqs.html", "/dawson-faqs-basics")
+
+    def test_tou_redirect(self):
+        """Test that /tou.html redirects to /dawson-tou."""
+        self._test_redirect("/tou.html", "/dawson-tou")
+
+    def test_sample_legacy_url_redirects(self):
+        """Test that sample legacy URLs are redirected correctly."""
+        # Test a few legacy URLs that should be transformed
+        test_cases = [
+            ("/administrative_orders.html", "/administrative-orders/"),
+            ("/case_procedure.html", "/case-procedure/"),
+            ("/citation_and_style_manual.html", "/citation-and-style-manual/"),
+            ("/dawson_faqs_basics.html", "/dawson-faqs-basics/"),
+            ("/employment.html", "/employment/"),
+        ]
+
+        for old_path, expected_new_path in test_cases:
+            with self.subTest(old_path=old_path):
+                self._test_redirect(old_path, expected_new_path)
+
+    def test_all_configured_redirects_work(self):
+        """Test that all configured redirects in REDIRECTS list work correctly."""
+        for redirect_config in REDIRECTS:
+            old_path = redirect_config["old_path"]
+            expected_new_path = redirect_config["new_path"]
+
+            with self.subTest(old_path=old_path):
+                self._test_redirect(old_path, expected_new_path)
+
+    def test_non_configured_paths_return_404(self):
+        """Test that paths not in the redirect configuration return 404."""
+        non_existent_paths = [
+            "/non_existent_path.html",
+            "/another_fake_path",
+            "/random_legacy_file.html",
+        ]
+
+        for path in non_existent_paths:
+            with self.subTest(path=path):
+                # Test that non-configured paths don't have redirects
+                redirect = Redirect.objects.filter(old_path=path).first()
+                self.assertIsNone(
+                    redirect, f"No redirect should exist for non-configured path {path}"
+                )
+
+                # Test that middleware doesn't create redirects for non-existent paths
+                request = self.factory.get(path)
+                middleware = RedirectMiddleware(lambda _: None)
+                mock_response = HttpResponseNotFound()
+                response = middleware.process_response(request, mock_response)
+
+                # Should return the original 404 response
+                self.assertEqual(response.status_code, 404)
+
+    def test_redirect_behavior_with_query_parameters(self):
+        """Test that redirects work with query parameters (query params are not preserved by default)."""
+        request = self.factory.get("/vacancy_announcements?test=value")
+        middleware = RedirectMiddleware(lambda _: None)
+        mock_response = HttpResponseNotFound()
+        response = middleware.process_response(request, mock_response)
+
+        self.assertEqual(response.status_code, 301)
+        # Note: Wagtail redirects do not preserve query parameters by default
+        self.assertEqual(response.url, "/employment/vacancy-announcements")


### PR DESCRIPTION
## Changes

- Add redirects for dawson-faqs.
- Refactor `RedirectInitializer` to introduce a `create` function that can take single path.
- Tests added to check all redirects work.