### PR TITLE
fix: Fix "add entries" button on Pamphlets page

### DIFF
--- a/website/home/models/pages/home_page.py
+++ b/website/home/models/pages/home_page.py
@@ -16,7 +16,7 @@ class HomePage(Page):
     content_panels = Page.content_panels + [
         FieldPanel("intro"),
         InlinePanel("images", label="Full Width Carousel Image"),
-        InlinePanel("entries", label="Entries"),
+        InlinePanel("entries", label="Entries", classname="inline-panel-no-add-button"),
     ]
 
     search_fields = Page.search_fields + [

--- a/website/home/templates/wagtailadmin/base.html
+++ b/website/home/templates/wagtailadmin/base.html
@@ -7,10 +7,6 @@
             margin-bottom: 3rem;
         }
 
-        #id_entries-ADD {
-            display: none !important;
-        }
-
         .admin-env-banner {
             background-color: #FAA500;
             color: #020103;
@@ -22,6 +18,10 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
+        }
+
+        .inline-panel-no-add-button #id_entries-ADD {
+            display: none !important;
         }
     </style>
 {% endblock %}


### PR DESCRIPTION
## Changes

- Add classname to disable add button for HomePage entries inline panel
- Move CSS selector from generic approach to specific class-based selector
- Fixes issue where multiple add buttons could appear in admin interface