### PR TITLE
Throw file not found error while loading the file in page initializer

### DIFF
--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_pay_filing_fee.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_pay_filing_fee.py
@@ -5,10 +5,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-docs = {
-    "dawson_pay_filing_fee.pdf": "",
-    "Application_for_Waiver_of_Filing_Fee.pdf": "",
-}
+docs = {"Application_for_Waiver_of_Filing_Fee.pdf": ""}
 
 images = {
     "dawson_filing_fee_option_pay_by_debit_credit_pay_now.png": "",

--- a/website/home/management/commands/pages/page_initializer.py
+++ b/website/home/management/commands/pages/page_initializer.py
@@ -84,7 +84,7 @@ class PageInitializer(ABC):
 
         if not os.path.exists(file_path):
             logger.warning(f"Document file not found at {file_path}")
-            return None
+            raise FileNotFoundError(f"Document file not found: {file_path}")
 
         Document = get_document_model()
 


### PR DESCRIPTION
## Changes

- Modify the the document loader in page initializer class to throw `"FileNotFoundError"` when loading the file.
- The new `"FileNotFoundError"` exception will break the `create-pages` command - as expected.
- Fixes one such file that is not used/referred.