### PR TITLE
added tag manager to snippets, main admin menu

### DIFF
--- a/website/home/models/__init__.py
+++ b/website/home/models/__init__.py
@@ -15,6 +15,7 @@ from home.models.snippets.navigation import (
     SubNavigationLinkBlock,  # noqa: F401
 )
 from home.models.snippets.common import CommonText  # noqa: F401
+from home.models.snippets.tagmanager import SnippetViewSet  # noqa: F401
 from home.models.pages.standard import StandardPage  # noqa: F401
 from home.models.custom_blocks.photo_dedication import PhotoDedicationBlock  # noqa: F401
 from home.models.custom_blocks.common import CommonBlock, link_obj, ColumnBlock  # noqa: F401

--- a/website/home/models/snippets/tagmanager.py
+++ b/website/home/models/snippets/tagmanager.py
@@ -1,0 +1,16 @@
+from wagtail.admin.panels import FieldPanel
+from wagtail.snippets.models import register_snippet
+from wagtail.snippets.views.snippets import SnippetViewSet
+from taggit.models import Tag
+
+
+@register_snippet
+class TagsSnippetViewSet(SnippetViewSet):
+    panels = [FieldPanel("name")]  # only show the name field
+    model = Tag
+    icon = "tag"  # change as required
+    add_to_admin_menu = True
+    menu_label = "Tags"
+    menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
+    list_display = ["name", "slug"]
+    search_fields = ("name",)


### PR DESCRIPTION
this commit lifts the exact code from the wagtail documentation site at https://docs.wagtail.org/en/stable/advanced_topics/tags.html#managing-tags-as-snippets

Despite being a snippet I notice that it also adds a menu item to the main admin UI. So it is accessible from two places.  Feels like it should be one place or the other but I also feel tag management is more important than figuring out where the menu item should appear.