### PR TITLE
Update Wagtail to 7 and Django to 5.2

### DIFF
--- a/website/.djlintrc
+++ b/website/.djlintrc
@@ -1,4 +1,6 @@
 {
   "profile": "django",
-  "exclude": "cypress/downloads/"
+  "exclude": "cypress/downloads/",
+  "extend_exclude": "node_modules/",
+  "encoding": "utf-8"
 }

--- a/website/.djlintrc
+++ b/website/.djlintrc
@@ -1,3 +1,4 @@
 {
-  "profile": "django"
+  "profile": "django",
+  "exclude": "cypress/downloads/"
 }

--- a/website/app/urls.py
+++ b/website/app/urls.py
@@ -95,9 +95,12 @@ if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
-    urlpatterns += [
-        path("__debug__/", include("debug_toolbar.urls")),
-    ]
+
+    # Only include debug_toolbar URLs if the app is installed
+    if "debug_toolbar" in settings.INSTALLED_APPS:
+        urlpatterns += [
+            path("__debug__/", include("debug_toolbar.urls")),
+        ]
 
 urlpatterns = urlpatterns + [
     # For anything not caught by a more specific rule above, hand over to

--- a/website/requirements/base.txt
+++ b/website/requirements/base.txt
@@ -52,5 +52,5 @@ urllib3==2.5.0
 virtualenv==20.28.0
 wagtail==7.0.2
 whitenoise==6.8.2
-Willow==1.9.0
+Willow
 social-auth-app-django==5.4.3

--- a/website/requirements/base.txt
+++ b/website/requirements/base.txt
@@ -15,7 +15,7 @@ django-permissionedforms==0.1
 django-storages==1.14.4
 django-taggit==6.1.0
 django-treebeard==4.7.1
-Django==5.1.7
+Django==5.2
 djangorestframework==3.15.2
 draftjs-exporter==5.0.0
 et_xmlfile==2.0.0
@@ -50,7 +50,7 @@ telepath==0.3.1
 typing_extensions==4.12.2
 urllib3==2.5.0
 virtualenv==20.28.0
-wagtail==6.4.1
+wagtail==7.0.2
 whitenoise==6.8.2
 Willow==1.9.0
 social-auth-app-django==5.4.3


### PR DESCRIPTION
## Changes

- Update Wagtail to 7.0.2
- Update Django to 5.2

## Tests

- [x] Admin console works as expected.
    - [x] Edit and publish pages.
    - [x] Moderator Workflow.
    - [x] Schedule publishing.
- [x] Check AWS console.
    - [x] Cloudwatch log has no errors.
    - [x] Cloudfront cache verify.
    - [x] ECS tasks are healthy.
- [x] Page rendering.
    - [x] HTML rendered as expected, with no display changes.
    - [x] Document links and other URLs are accessible.
    - [x] Search works.

wagtail id: WAG-052