### PR TITLE
Handle moderation workflow errors in Admin page

### DIFF
--- a/website/home/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/website/home/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags error_tags %}
 {% if states %}
     {% comment %}Error handling wrapper for workflow moderation{% endcomment %}
     <div class="moderation-notification-bar">
@@ -54,6 +54,7 @@
             padding: 2px 4px;
         }
     </style>
+    {% safe_block %}
     <table class="listing listing--dashboard">
         <col />
         <col width="25%" />
@@ -200,6 +201,7 @@
             {% endfor %}
         </tbody>
     </table>
+    {% endsafe_block %}
 {% endpanel %}
 <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"
         data-activate="dashboard"></script>

--- a/website/home/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/website/home/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -1,6 +1,9 @@
 {% load i18n wagtailadmin_tags %}
 {% if states %}
-    <div class="moderation-notification-bar"><span>⚠️ You have edits waiting for your review.</span></div>
+    {% comment %}Error handling wrapper for workflow moderation{% endcomment %}
+    <div class="moderation-notification-bar">
+        <span>⚠️ You have edits waiting for your review.</span>
+    </div>
     {% panel id="awaiting-review" heading=_("Awaiting your review") classname="w-panel--dashboard" %}
     <style>
         .workflow-action-buttons {
@@ -31,6 +34,17 @@
 
         .workflow-action-buttons .button:hover {
             opacity: 0.8;
+        }
+
+        .workflow-action-buttons .button-disabled {
+            background: #f5f5f5;
+            color: #999;
+            border-color: #ddd;
+            cursor: not-allowed;
+        }
+
+        .workflow-action-buttons .button-disabled:hover {
+            opacity: 1;
         }
 
         .yellow-label {
@@ -64,77 +78,118 @@
                     {% if is_page %}
                         {% page_permissions obj as page_perms %}
                     {% endif %}
-                    <tr>
-                        <td class="title">
-                            <!-- 1.  Title -->
-                            <div class="title-wrapper">
-                                {% admin_edit_url obj as edit_url %}
-                                {% if page_perms.can_edit or not is_page and edit_url %}
-                                    <a href="{{ edit_url }}" title="{% trans 'Edit' %}">{% latest_str obj %}</a>
-                                {% else %}
-                                    {% latest_str obj %}
-                                {% endif %}
-                            </div>
-                            {% if not state.live_revision_id %}
-                                <span class="yellow-label">{% trans "New page" %}</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <!-- 2.  Actions -->
-                            <div class="workflow-action-buttons">
-                                <!-- Preview button (default) -->
-                                {% if state.live_revision_id %}
-                                    <a href="{% url state.revisions_compare_url_name obj.pk|admin_urlquote 'live' revision.id %}"
-                                       class="button button-primary">{% trans 'Review' %}</a>
-                                {% else %}
-                                    <a href="{% url state.workflow_preview_url_name obj.pk|admin_urlquote task_state.task.id %}"
-                                       target="_blank"
-                                       rel="noreferrer"
-                                       class="button button-primary">{% trans 'Preview new page' %}</a>
-                                {% endif %}
-                                <!-- Workflow action buttons in correct order -->
-                                {% regroup actions by 0 as action_groups %}
-                                <!-- Publish button first (only first approve action) -->
-                                {% for action_name, action_label, modal in actions %}
-                                    {% if action_name == 'approve' %}
-                                        {% ifchanged action_name %}
-                                            <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}"
-                                                    data-launch-modal
-                                                    class="button">{% trans 'Publish' %}</button>
-                                        {% endifchanged %}
+                    {% comment %}Validate required objects exist before rendering{% endcomment %}
+                    {% if not obj or not task_state %}
+                        <tr>
+                            <td colspan="6" class="error-message">
+                                <span style="color: #d63638; font-style: italic;">
+                                    {% trans "Error: Unable to load workflow data for this item." %}
+                                </span>
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr>
+                            <td class="title">
+                                <!-- 1.  Title -->
+                                <div class="title-wrapper">
+                                    {% admin_edit_url obj as edit_url %}
+                                    {% if page_perms.can_edit or not is_page and edit_url %}
+                                        <a href="{{ edit_url }}" title="{% trans 'Edit' %}">
+                                            {% if obj.title %}
+                                                {{ obj.title }}
+                                            {% elif obj %}
+                                                {{ obj }}
+                                            {% else %}
+                                                {% trans "Untitled" %}
+                                            {% endif %}
+                                        </a>
+                                    {% else %}
+                                        {% if obj.title %}
+                                            {{ obj.title }}
+                                        {% elif obj %}
+                                            {{ obj }}
+                                        {% else %}
+                                            {% trans "Untitled" %}
+                                        {% endif %}
                                     {% endif %}
-                                {% endfor %}
-                                <!-- Request changes button second (only first reject action) -->
-                                {% for action_name, action_label, modal in actions %}
-                                    {% if action_name == 'reject' %}
-                                        {% ifchanged action_name %}
-                                            <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}"
-                                                    {% if modal %}data-launch-modal{% endif %}
-                                                    class="button">{% trans 'Request changes' %}</button>
-                                        {% endifchanged %}
-                                    {% endif %}
-                                {% endfor %}
-                            </div>
-                        </td>
-                        <td class="tasks">
-                            <!-- 3.  Notes -->
-                            {% for task in workflow_tasks %}{{ task.name }}{% endfor %}
-                        </td>
-                        <td>
-                            <!-- 4.  Task submitted by-->
-                            {% if revision.user %}{{ revision.user|user_display_name }}{% endif %}
-                        </td>
-                        <!-- 5.  Task started -->
-                        <td>{% human_readable_date task_state.started_at %}</td>
-                        <td class="actions-container">
-                            <!-- 6 -->
-                            {% if actions %}
-                                {% if page_perms.can_edit or not is_page and edit_url %}
-                                    <a href="{{ edit_url }}">{% trans 'Edit' %}</a>
+                                </div>
+                                {% if not state.live_revision_id %}
+                                    <span class="yellow-label">{% trans "New page" %}</span>
                                 {% endif %}
-                            {% endif %}
-                        </td>
-                    </tr>
+                            </td>
+                            <td>
+                                <!-- 2.  Actions -->
+                                <div class="workflow-action-buttons">
+                                    <!-- Preview button (default) -->
+                                    {% if state.live_revision_id and state.revisions_compare_url_name %}
+                                        <a href="{% url state.revisions_compare_url_name obj.pk|admin_urlquote 'live' revision.id %}"
+                                           class="button button-primary">{% trans 'Review' %}</a>
+                                    {% elif state.workflow_preview_url_name %}
+                                        <a href="{% url state.workflow_preview_url_name obj.pk|admin_urlquote task_state.task.id %}"
+                                           target="_blank"
+                                           rel="noreferrer"
+                                           class="button button-primary">{% trans 'Preview new page' %}</a>
+                                    {% else %}
+                                        <span class="button button-disabled">{% trans 'Preview unavailable' %}</span>
+                                    {% endif %}
+                                    <!-- Workflow action buttons in correct order -->
+                                    {% if state.workflow_action_url_name %}
+                                        {% regroup actions by 0 as action_groups %}
+                                        <!-- Publish button first (only first approve action) -->
+                                        {% for action_name, action_label, modal in actions %}
+                                            {% if action_name == 'approve' %}
+                                                {% ifchanged action_name %}
+                                                    <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}"
+                                                            data-launch-modal
+                                                            class="button">{% trans 'Publish' %}</button>
+                                                {% endifchanged %}
+                                            {% endif %}
+                                        {% endfor %}
+                                        <!-- Request changes button second (only first reject action) -->
+                                        {% for action_name, action_label, modal in actions %}
+                                            {% if action_name == 'reject' %}
+                                                {% ifchanged action_name %}
+                                                    <button data-workflow-action-url="{% url state.workflow_action_url_name obj.pk|admin_urlquote action_name task_state.id %}"
+                                                            {% if modal %}data-launch-modal{% endif %}
+                                                            class="button">{% trans 'Request changes' %}</button>
+                                                {% endifchanged %}
+                                            {% endif %}
+                                        {% endfor %}
+                                    {% else %}
+                                        <span class="button button-disabled">{% trans 'Actions unavailable' %}</span>
+                                    {% endif %}
+                                </div>
+                            </td>
+                            <td class="tasks">
+                                <!-- 3.  Notes -->
+                                {% for task in workflow_tasks %}{{ task.name }}{% endfor %}
+                            </td>
+                            <td>
+                                <!-- 4.  Task submitted by-->
+                                {% if revision and revision.user %}
+                                    {{ revision.user|user_display_name }}
+                                {% else %}
+                                    <span style="color: #999; font-style: italic;">{% trans "Unknown" %}</span>
+                                {% endif %}
+                            </td>
+                            <!-- 5.  Task started -->
+                            <td>
+                                {% if task_state.started_at %}
+                                    {% human_readable_date task_state.started_at %}
+                                {% else %}
+                                    <span style="color: #999; font-style: italic;">{% trans "Unknown" %}</span>
+                                {% endif %}
+                            </td>
+                            <td class="actions-container">
+                                <!-- 6 -->
+                                {% if actions %}
+                                    {% if page_perms.can_edit or not is_page and edit_url %}
+                                        <a href="{{ edit_url }}">{% trans 'Edit' %}</a>
+                                    {% endif %}
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endif %}
                 {% endwith %}
             {% endfor %}
         </tbody>

--- a/website/home/templates/wagtailadmin/home/workflow_objects_to_moderate.html
+++ b/website/home/templates/wagtailadmin/home/workflow_objects_to_moderate.html
@@ -114,7 +114,13 @@
                                     {% endif %}
                                 </div>
                                 {% if not state.live_revision_id %}
-                                    <span class="yellow-label">{% trans "New page" %}</span>
+                                    <span class="yellow-label">
+                                        {% if is_page %}
+                                            {% trans "New page" %}
+                                        {% else %}
+                                            {% trans "New content" %}
+                                        {% endif %}
+                                    </span>
                                 {% endif %}
                             </td>
                             <td>

--- a/website/home/templatetags/error_tags.py
+++ b/website/home/templatetags/error_tags.py
@@ -1,0 +1,33 @@
+from django import template
+import logging
+
+logger = logging.getLogger(__name__)
+
+register = template.Library()
+
+
+@register.tag(name="safe_block")
+def do_safe_block(parser, token):
+    """
+    A template tag that catches and logs exceptions during rendering.
+
+    Usage:
+    {% safe_block %}
+        ... template code that might fail ...
+    {% endsafe_block %}
+    """
+    nodelist = parser.parse(("endsafe_block",))
+    parser.delete_first_token()
+    return SafeNode(nodelist)
+
+
+class SafeNode(template.Node):
+    def __init__(self, nodelist):
+        self.nodelist = nodelist
+
+    def render(self, context):
+        try:
+            return self.nodelist.render(context)
+        except Exception as e:
+            logger.warning("Error rendering block in safe_block: %s", e, exc_info=True)
+            return f'<div class="error-message" style="color: red; border: 1px solid red; padding: 10px;">Template rendering error: {e}</div>'


### PR DESCRIPTION
## Change

- New Snippets submitted for moderation will have [New content] label instead of [New page].
    - Preview button will be disabled and captioned [Preview unavailable] instead.
- Handle moderation workflow errors in admin page.
    - Safely process and render the HTML content.
    - When processing error occurs, display a message (don't fail silently).

### Tests

<img width="743" height="273" alt="image" src="https://github.com/user-attachments/assets/ca67ae67-374e-4898-9576-7f805453d2f4" />
