### PR TITLE
BUG: Sometimes edits submitted for moderation are marked New Page- WAG 435

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -126,3 +126,6 @@ rollbackmigrate:
 
 rollbackall:
 	. $(VENV) && python manage.py migrate home zero
+
+backfillliverevisions:
+	. $(VENV) && DJANGO_SETTINGS_MODULE=$${settings:-app.settings.local} python manage.py backfill_live_revisions

--- a/website/home/management/commands/backfill_live_revisions.py
+++ b/website/home/management/commands/backfill_live_revisions.py
@@ -1,0 +1,123 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+from django.contrib.contenttypes.models import ContentType
+
+from wagtail.models import Page as LivePage
+
+REVISION_IMPL = None
+REVISION_FIELD_NAME = (
+    None  # "content_json" for PageRevision, "content" for generic Revision
+)
+USE_PAGEREVISION = False
+
+try:
+    from wagtail.models import PageRevision  # type: ignore
+
+    REVISION_IMPL = PageRevision
+    REVISION_FIELD_NAME = "content_json"
+    USE_PAGEREVISION = True
+except Exception:
+    try:
+        from wagtail.models import Revision  # type: ignore
+
+        REVISION_IMPL = Revision
+        REVISION_FIELD_NAME = "content"
+        USE_PAGEREVISION = False
+    except Exception:
+        REVISION_IMPL = None
+
+
+class Command(BaseCommand):
+    help = "Backfill a live revision for any live Page that has no live_revision. Drafts remain untouched."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would change, do not write.",
+        )
+        parser.add_argument(
+            "--limit", type=int, default=500, help="Max pages to process this run."
+        )
+
+    def handle(self, *args, **opts):
+        if REVISION_IMPL is None:
+            self.stderr.write(
+                self.style.ERROR(
+                    "Could not import a Wagtail Revision model (PageRevision or Revision). "
+                    "Check your Wagtail version and imports."
+                )
+            )
+            return
+
+        dry = opts["dry_run"]
+        limit = opts["limit"]
+
+        qs = LivePage.objects.filter(live=True, live_revision__isnull=True).order_by(
+            "id"
+        )
+        if limit:
+            qs = qs[:limit]
+
+        count = qs.count()
+        if count == 0:
+            self.stdout.write(self.style.SUCCESS("No pages need backfill."))
+            return
+
+        self.stdout.write(f"Found {count} live pages without live_revision.")
+        self.stdout.write(
+            f"Using {'PageRevision' if USE_PAGEREVISION else 'generic Revision'} model."
+        )
+
+        with transaction.atomic():
+            for page in qs.select_related():
+                specific = page.specific
+                snapshot = specific.to_json()
+
+                created_at = (
+                    page.last_published_at
+                    or getattr(page, "first_published_at", None)
+                    or timezone.now()
+                )
+
+                if dry:
+                    self.stdout.write(
+                        f"[DRY] Would create live revision for Page(id={page.id}, title={page.title!r}) at {created_at}."
+                    )
+                    continue
+
+                if USE_PAGEREVISION:
+                    # Classic PageRevision (field is content_json)
+                    kwargs = {
+                        "page_id": page.id,
+                        "created_at": created_at,
+                        "user": None,
+                        "submitted_for_moderation": False,
+                        "approved_go_live_at": None,
+                        "content_json": snapshot,
+                    }
+                    rev = REVISION_IMPL.objects.create(**kwargs)
+                else:
+                    # Generic Revision (field is content)
+                    ct = ContentType.objects.get_for_model(specific.__class__)
+                    kwargs = {
+                        "content_type": ct,
+                        "object_id": page.id,
+                        "created_at": created_at,
+                        "user": None,
+                        "approved_go_live_at": None,
+                        REVISION_FIELD_NAME: snapshot,
+                    }
+                    rev = REVISION_IMPL.objects.create(**kwargs)
+
+                # Point the page at this revision as live without touching drafts
+                page.live_revision = rev
+
+                # Only set latest_revision_created_at if it's currently null
+                if not page.latest_revision_created_at:
+                    page.latest_revision_created_at = created_at
+
+                page.save(update_fields=["live_revision", "latest_revision_created_at"])
+
+        self.stdout.write(self.style.SUCCESS("Backfill complete."))


### PR DESCRIPTION
Add backfill_live_revisions command to fix missing live revisions on already published pages/snippets

Some pages were flagged as "new" during moderation because they had no associated live_revision record. This prevented proper draft vs live comparisons in the moderation dashboard.

This change introduces a management command `backfill_live_revisions` that:

- Creates a synthetic live revision for any live page without one
- Leaves existing drafts and has_unpublished_changes untouched
- Detects Wagtail version and uses the correct revision model
  (PageRevision vs Revision)

This ensures moderation compare works correctly and pages are no longer incorrectly labeled as "new".


### Screeshort
### Before
<img width="1604" height="298" alt="Screenshot 2025-08-22 at 2 58 05 PM" src="https://github.com/user-attachments/assets/3d9b2d40-03a9-44eb-9d28-8a05b65e080c" />



### After changes

<img width="1603" height="261" alt="Screenshot 2025-08-22 at 2 51 31 PM" src="https://github.com/user-attachments/assets/a5f16165-d442-4eac-86f8-bc88b12f0bfd" />

