### PR TITLE
WAG-375: introduce git naming conventions to contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,22 @@ Requirements are installed using `pip`. Local/development requirements go to `lo
 
 See: https://github.com/octoenergy/public-conventions/blob/main/conventions/terraform.md
 
+## Git Naming Conventions
+
+We are using Monday.com as an issue tracking system for project management. In order to get better metrics for performance and connect the code with the issues, we are requiring the following naming conventions for branches and pull requests. We are also welcoming, but not requiring, the following naming convention for commits:
+
+### Branch Names
+
+Please use a branch name that includes the Task ID in the name. **It must be uppercase** for it to properly link to the issue. For example, if the Task ID is "WAG-123" then the branch name should begin with "WAG-123-..." After that please use a brief summary of the work that the branch will do. 
+
+### Pull Request Titles
+
+Please reference the Task ID in the Title or Description of any pull request. This way the Github integration will automatically connect a task in Monday.com with the Pull Request. Again, **it must be uppercase**. This will give us better insights and help drive decision making. For example, when you create a PR, please give it the title "Introduce Git Naming Conventions - WAG-375" or mention it in the description. 
+
+### Commit Messages
+
+Please consider using the Task ID in the commit messages themselves. If you do this, please use it as a prefix. For example, "WAG-375: introduce git naming convention to contributing notes" would connect this commit with our project management system.
+
 ## Reference
 
 1. Django specific coding style recommendations from: Hacksoft Django Styleguide: https://github.com/HackSoftware/Django-Styleguide


### PR DESCRIPTION
This PR prescribes our github naming convention for PRs, branches, and Commits. This will help give us better insight into team performance, help us make better decisions, and connect the code with the issues themselves so we can figure out how we fixed something in the past.