### PR TITLE
WAG-456: remove entries and press_release_body from admin UI

### DIFF
--- a/website/home/models/pages/home_page.py
+++ b/website/home/models/pages/home_page.py
@@ -39,7 +39,7 @@ class HomePage(ModerationMixin, Page):
     content_panels = Page.content_panels + [
         FieldPanel("intro"),
         InlinePanel("images", label="Full Width Carousel Image"),
-        InlinePanel("entries", label="Entries", classname="inline-panel-no-add-button"),
+        # InlinePanel("entries", label="Entries", classname="inline-panel-no-add-button"),
         FieldPanel("static_text_cards"),
     ]
 

--- a/website/home/models/pages/press_release.py
+++ b/website/home/models/pages/press_release.py
@@ -6,14 +6,11 @@ from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.fields import StreamField
 from wagtail.search import index
-from wagtail.admin.panels import FieldPanel
 from django.utils import timezone
 from django.template.response import TemplateResponse
 
 from home.models.custom_blocks.button import ButtonBlock
 from home.models.pages.enhanced_standard import EnhancedStandardPage
-from home.admin.moderation import ModerationTabbedInterface
-from home.models.custom_blocks.common import custom_promote_panels
 from home.models.snippets.news_item import NewsItem
 
 
@@ -54,18 +51,9 @@ class PressReleasePage(RoutablePageMixin, EnhancedStandardPage):
         null=True,
     )
 
-    content_panels = EnhancedStandardPage.content_panels + [
-        FieldPanel("press_release_body"),
-    ]
-
     search_fields = EnhancedStandardPage.search_fields + [
         index.SearchField("press_release_body"),
     ]
-
-    edit_handler = ModerationTabbedInterface.create_for_page(
-        content_panels=content_panels,
-        promote_panels=custom_promote_panels,
-    )
 
     @route("archives/")
     def archive_view(self, request):


### PR DESCRIPTION
This PR removes "home page entries" and "press release body" from the Home Page edit page and the Press Release & News edit page, respectively.  While we want to retain the data from these fields for the time being, we no longer wish to show them in the admin UI as their functionality has been replaced with the News Item snippet model. The need to actually edit these pages in wagtail will largely go away as users will indirectly populate these pages by adding News Items

## New Home Page edit UI
<img width="1443" height="1169" alt="image" src="https://github.com/user-attachments/assets/b6bbe8ed-8a77-457a-8f06-1e4fc1f5e5ed" />


## New Press Release edit UI
<img width="1443" height="1169" alt="image" src="https://github.com/user-attachments/assets/3386612e-9b5a-4048-92b2-c80c252f6ac2" />

## News Item edit UI 
<img width="1443" height="1169" alt="image" src="https://github.com/user-attachments/assets/9bb73dc9-a379-45ca-9c02-f65b3151d7aa" />

