### PR TITLE
WAG-436: Fix spacing between paragraphs in richtext paragraph field

### DIFF
--- a/website/home/templates/home/enhanced_standard_page.html
+++ b/website/home/templates/home/enhanced_standard_page.html
@@ -36,11 +36,6 @@
             display: none;
         }
 
-        .enhanced-page p,
-        .enhanced-page .list-block p {
-            margin: 0;
-        }
-
         .enhanced-page .nested-list img {
             padding-top: 1rem;
             display: block;


### PR DESCRIPTION
Introduction: I found the PR that introduced the margin:0 style on .list-block p elements in enhanced standard page. The specific commit message is "removing extra margin on p tag added when publishing" and it is part of a PR to add the Find An Opinion Page #202. 

Investigation: That PR also comments out a 1rem bottom-margin on list-items. I checked out that code, uncommented the bottom margin on list-items and commented out the code removed in this PR. I then saw the issue solved in the commit adding this code. I re-commented the list item bottom margin and also left the code removed in this PR commented out. It seems that removing the bottom margin on list-items was what solved the styling issues rather than adding the mergin:0 style on .list-block p elements. 

Conclusion: I believe that this code was added to solve a style issue solved by another change and this code was forgotten. I don't believe that this fix should cause other issues but I urge reviewers to also check out the code from PR #202 and experiment as above to confirm, and also check out this PR to confirm functionality.