### PR TITLE
bumping deploy timeout to 75min

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
   deploy:
     environment: ${{ github.ref == 'refs/tags/development' && 'development' || github.ref == 'refs/tags/sandbox' && format('{0}_sandbox', github.actor) || github.ref == 'refs/heads/main' && 'development' || github.ref == 'refs/tags/train' && 'train' || '' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - name: Set Environment
         id: set_env


### PR DESCRIPTION
this update simply increases the deploy timeout to 75 minutes, which should help fresh deploys during github slow periods