### PR TITLE
password enabled, not required for all envs

### DIFF
--- a/website/app/settings/base.py
+++ b/website/app/settings/base.py
@@ -118,16 +118,13 @@ TEMPLATES = [
     },
 ]
 
-# Looks for an environment variable named ENABLE_LOCAL_LOGIN.
-# If it doesn’t exist, it defaults to "False" (a string).
-# Checks whether the lowercase string is either "true" or "1".
-# If yes → returns True else False
+# If True, allow non-SSO users to login. Otherwise prevent login w/ wagtail credentials.
 ENABLE_LOCAL_LOGIN = True
 
 # Disable/enables password when new users are being created in admin console.
 # Default : False
 WAGTAILUSERS_PASSWORD_REQUIRED = False
-WAGTAILUSERS_PASSWORD_ENABLED = False
+WAGTAILUSERS_PASSWORD_ENABLED = True
 
 # Azure AD (python-social-auth) configuration
 SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY = os.getenv(

--- a/website/app/settings/local.py
+++ b/website/app/settings/local.py
@@ -28,10 +28,6 @@ WAGTAIL_SITE_NAME = "A testing site for US Tax Court Web Development"
 # Uses localhost:8000/admin
 LOGIN_URL = "/admin/"
 
-# Enables password for creating users since sso does not work in local
-WAGTAILUSERS_PASSWORD_REQUIRED = True
-WAGTAILUSERS_PASSWORD_ENABLED = True
-
 # Use the simple logger when running local
 LOGGING["root"]["handlers"] = ["simple"]
 LOGGING["loggers"]["django"]["handlers"] = ["simple"]


### PR DESCRIPTION
This update just tweaks the `WAGTAILUSERS_PASSWORD_ENABLED` setting so that password fields are shown on the wagtail user account form, but they are not required.   Not specifying a password on a new account effectively prohibits the account from using wagtail authentication (SSO authentication still works, which is our preference).

This change affects all environments, including production.

This setting will give administrators maximum flexibility:
- administrators can create new users and force them to use SSO auth by not specifying a password
- administrators can reset the root administrator password without performing a redeploy

Note that users can still create non-sso users in theory.  However, in practice deploys will fail if an environment has more than one non-sso user (the expectation being that the one non-sso user will be the root admin).