### PR TITLE
WAG-477: heading, footer fonts not using Source Sans Pro.

### DIFF
--- a/website/app/static/css/app.css
+++ b/website/app/static/css/app.css
@@ -13,8 +13,8 @@
     --link-blue: rgb(0, 94, 162);
     --color-primary-alt-lightest: #F1F9FC;
     --color-accent-cool-light: #97D4EA;
-    --heading-font: "Source Sans Pro";
-    --body-font: 'Source Sans Pro';
+    --heading-font: "Source Sans 3";
+    --body-font: 'Source Sans 3';
     --base-font-size: 17px;
     --container-width: 1440px;
 }
@@ -39,19 +39,19 @@ body {
    Typography
    ========================================================================== */
 .font-heading {
-    font-family: var(--heading-font);
+    font-family: var(--heading-font), sans-serif;
 }
 
 body {
     line-height: 24px;
-    font-family: var(--body-font);
+    font-family: var(--body-font), sans-serif;
     font-size: var(--base-font-size);
     -webkit-font-smoothing: antialiased;
 }
 
 /* Headings */
 h1, h2, h3, h4, h5, h6 {
-    font-family: var(--heading-font);
+    font-family: var(--heading-font), sans-serif;
     font-weight: bold;
     line-height: 38px;
     margin-bottom: 8px;
@@ -73,13 +73,13 @@ h2 {
 h3 {
     font-size: 1.25rem;
     line-height: 1.563rem;
-    font-family: 'Source Sans Pro';
+    font-family: 'Source Sans 3', sans-serif;
 }
 
 h4 {
     font-size: 1.063rem;
     line-height: 1.5rem;
-    font-family: 'Source Sans Pro';
+    font-family: 'Source Sans 3', sans-serif;
 }
 
 /* Links */

--- a/website/app/templates/base.html
+++ b/website/app/templates/base.html
@@ -92,6 +92,7 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;700&text=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789%26%24&family=Source+Sans+Pro:wght@400;700&display=swap"
               rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap" rel="stylesheet">
         <script defer type="text/javascript" src="{% static 'js/app.js' %}"></script>
         <script defer
                 type="text/javascript"

--- a/website/app/templates/footer.html
+++ b/website/app/templates/footer.html
@@ -9,7 +9,7 @@
 
     footer#app-footer .main .title {
         font-size: 1.4rem;
-        font-family: var(--heading-font);
+        font-family: var(--heading-font), sans-serif;
         font-weight: 600;
         line-height: 2rem;
         margin-bottom: 8px;

--- a/website/cypress/support/commands.ts
+++ b/website/cypress/support/commands.ts
@@ -76,11 +76,11 @@ export function checkHeaderOrder() {
 
 export function checkHeaderStyles() {
     const headerStyles = {
-        h1: { fontFamily: 'Source Sans Pro', fontSize: '32px', lineHeight: '40px' },
-        'h2:not(footer h2)': { fontFamily: 'Source Sans Pro', fontSize: '24px', lineHeight: '30px' },
-        'footer h2': { fontFamily: 'Source Sans Pro', fontSize: '20px', lineHeight:'normal'},
-        h3: { fontFamily: 'Source Sans Pro', fontSize: '20px', lineHeight: '25px' },
-        h4: { fontFamily: 'Source Sans Pro', fontSize: '17px', lineHeight: '24px' },
+        h1: { fontFamily: 'Source Sans 3', fontSize: '32px', lineHeight: '40px' },
+        'h2:not(footer h2)': { fontFamily: 'Source Sans 3', fontSize: '24px', lineHeight: '30px' },
+        'footer h2': { fontFamily: 'Source Sans 3', fontSize: '20px', lineHeight:'normal'},
+        h3: { fontFamily: 'Source Sans 3', fontSize: '20px', lineHeight: '25px' },
+        h4: { fontFamily: 'Source Sans 3', fontSize: '17px', lineHeight: '24px' },
     };
     Object.entries(headerStyles).forEach(([header, styles]) => {
         cy.get('body').then(($body) => {

--- a/website/home/templates/home/dawson_page.html
+++ b/website/home/templates/home/dawson_page.html
@@ -51,7 +51,7 @@
         #dawson-page .usa-card-group .usa-card .usa-card__container .usa-card__header p {
             font-size: 17px;
             line-height: 24px;
-            font-family: var(--heading-font);
+            font-family: var(--heading-font), sans-serif;
             font-weight: 700;
         }
 


### PR DESCRIPTION
This addresses the font issues mentioned in https://ustc-isd.monday.com/item/WAG-477.  This font was not being imported by any of templates and/or css files.   I also discovered that  Source Sans Pro is difficult to obtain, but it's successor, "Source Sans 3", is easy to acquire and also hosted on Google Fonts.   Since we already use Google Fonts for Noto Serif and, I've opted to use google for Source Sans 3 as well.

Before:
<img width="370" height="85" alt="Screenshot 2025-10-07 at 10 51 16 AM" src="https://github.com/user-attachments/assets/8a21179a-618c-40aa-abd6-5535f608d40c" />

After:
<img width="367" height="85" alt="Screenshot 2025-10-07 at 10 51 37 AM" src="https://github.com/user-attachments/assets/f704b65a-66fa-4f7e-980b-198051fb4b8f" />
