### PR TITLE
migrate issues

### DIFF
--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_find_a_case.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_find_a_case.py
@@ -58,7 +58,10 @@ class FindACasePageInitializer(PageInitializer):
                     {"type": "hr", "value": True},
                     {
                         "type": "image",
-                        "value": uploaded_images["find-a-case.jpg"]["id"],
+                        "value": {
+                            "image": uploaded_images["find-a-case.jpg"]["id"],
+                            "link": [],
+                        },
                     },
                     {"type": "hr", "value": True},
                     {

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_find_a_case.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_find_a_case.py
@@ -59,7 +59,10 @@ class FindACasePageInitializer(PageInitializer):
                     {
                         "type": "image",
                         "value": {
-                            "image": uploaded_images["find-a-case.jpg"]["id"],
+                            "image": {
+                                "image": uploaded_images["find-a-case.jpg"]["id"],
+                                "alt_text": "Screenshot of the DAWSON Find a Case search interface",
+                            },
                             "link": [],
                         },
                     },

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_pay_filing_fee.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_pay_filing_fee.py
@@ -148,9 +148,12 @@ class DawsonPayFilingFeeInitializer(PageInitializer):
                     {
                         "type": "image",
                         "value": {
-                            "image": images[
-                                "dawson_filing_fee_option_pay_by_debit_credit_pay_now.png"
-                            ].id,
+                            "image": {
+                                "image": images[
+                                    "dawson_filing_fee_option_pay_by_debit_credit_pay_now.png"
+                                ].id,
+                                "alt": "",
+                            },
                             "link": [],
                         },
                     },

--- a/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_pay_filing_fee.py
+++ b/website/home/management/commands/pages/efiling_and_case_maintenance/dawson_pay_filing_fee.py
@@ -151,7 +151,7 @@ class DawsonPayFilingFeeInitializer(PageInitializer):
                             "image": images[
                                 "dawson_filing_fee_option_pay_by_debit_credit_pay_now.png"
                             ].id,
-                            "alt_text": "Pay filing fee option using debit or credit card",
+                            "link": [],
                         },
                     },
                     {

--- a/website/home/migrations/0109_migrate_image_block_data.py
+++ b/website/home/migrations/0109_migrate_image_block_data.py
@@ -1,0 +1,95 @@
+"""Data migration: convert image blocks from bare int format to
+ImageWithLinkBlock StructBlock format.
+
+Existing pages store image blocks as:
+    {"type": "image", "value": 42}
+
+The new ImageWithLinkBlock expects:
+    {"type": "image", "value": {"image": 42, "link": []}}
+
+This must run before update_index or any StreamField deserialization
+of pages containing old-format image blocks.
+"""
+
+import json
+
+from django.db import migrations
+
+
+def convert_image_block_data(apps, schema_editor):
+    """Use raw SQL to avoid StreamField deserialization issues in migrations."""
+    connection = schema_editor.connection
+    cursor = connection.cursor()
+
+    cursor.execute("SELECT page_ptr_id, body FROM home_enhancedstandardpage")
+    rows = cursor.fetchall()
+
+    for page_id, body_raw in rows:
+        if not body_raw:
+            continue
+
+        body_data = json.loads(body_raw) if isinstance(body_raw, str) else body_raw
+
+        if not isinstance(body_data, list):
+            continue
+
+        changed = False
+        for block in body_data:
+            if block.get("type") != "image":
+                continue
+
+            value = block.get("value")
+
+            if isinstance(value, int):
+                block["value"] = {"image": value, "link": []}
+                changed = True
+
+        if changed:
+            cursor.execute(
+                "UPDATE home_enhancedstandardpage SET body = %s WHERE page_ptr_id = %s",
+                [json.dumps(body_data), page_id],
+            )
+
+
+def reverse_migration(apps, schema_editor):
+    """Reverse: convert back to bare int format."""
+    connection = schema_editor.connection
+    cursor = connection.cursor()
+
+    cursor.execute("SELECT page_ptr_id, body FROM home_enhancedstandardpage")
+    rows = cursor.fetchall()
+
+    for page_id, body_raw in rows:
+        if not body_raw:
+            continue
+
+        body_data = json.loads(body_raw) if isinstance(body_raw, str) else body_raw
+
+        if not isinstance(body_data, list):
+            continue
+
+        changed = False
+        for block in body_data:
+            if block.get("type") != "image":
+                continue
+
+            value = block.get("value")
+            if isinstance(value, dict) and "image" in value:
+                block["value"] = value["image"]
+                changed = True
+
+        if changed:
+            cursor.execute(
+                "UPDATE home_enhancedstandardpage SET body = %s WHERE page_ptr_id = %s",
+                [json.dumps(body_data), page_id],
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("home", "0108_alter_enhancedstandardpage_body"),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_image_block_data, reverse_migration),
+    ]

--- a/website/home/migrations/0109_migrate_image_block_data.py
+++ b/website/home/migrations/0109_migrate_image_block_data.py
@@ -1,11 +1,17 @@
-"""Data migration: convert image blocks from bare int format to
-ImageWithLinkBlock StructBlock format.
+"""Data migration: convert image blocks to ImageWithLinkBlock StructBlock format.
 
-Existing pages store image blocks as:
-    {"type": "image", "value": 42}
+Existing pages may store image blocks in one of two legacy formats:
 
-The new ImageWithLinkBlock expects:
-    {"type": "image", "value": {"image": 42, "link": []}}
+  1. Bare integer (old ImageChooserBlock format):
+         {"type": "image", "value": 42}
+
+  2. ImageBlock dict (old ImageBlock format):
+         {"type": "image", "value": {"image": 42, "alt_text": "...", "decorative": false}}
+
+The new ImageWithLinkBlock expects the image to be nested under an ``image`` key
+and a ``link`` StreamBlock list alongside it:
+
+    {"type": "image", "value": {"image": {"image": 42, ...}, "link": []}}
 
 This must run before update_index or any StreamField deserialization
 of pages containing old-format image blocks.
@@ -41,6 +47,12 @@ def convert_image_block_data(apps, schema_editor):
             value = block.get("value")
 
             if isinstance(value, int):
+                # Old bare-int format → wrap into nested ImageBlock dict then ImageWithLinkBlock
+                block["value"] = {"image": {"image": value}, "link": []}
+                changed = True
+            elif isinstance(value, dict) and "link" not in value:
+                # Old ImageBlock dict format (e.g. {"image": <id>, "alt_text": ..., "decorative": ...})
+                # → wrap into ImageWithLinkBlock, preserving the existing ImageBlock data
                 block["value"] = {"image": value, "link": []}
                 changed = True
 
@@ -75,14 +87,15 @@ def reverse_migration(apps, schema_editor):
 
             value = block.get("value")
             if isinstance(value, dict) and "image" in value:
-                image_val = value["image"]
+                image_block_val = value["image"]
                 image_id = None
-                if isinstance(image_val, int):
-                    image_id = image_val
-                elif isinstance(image_val, dict):
-                    possible_id = image_val.get("id")
-                    if isinstance(possible_id, int):
-                        image_id = possible_id
+                if isinstance(image_block_val, dict):
+                    # image_block_val is an ImageBlock dict: {"image": <int_id>, ...}
+                    inner = image_block_val.get("image")
+                    if isinstance(inner, int):
+                        image_id = inner
+                elif isinstance(image_block_val, int):
+                    image_id = image_block_val
                 if image_id is not None:
                     block["value"] = image_id
                     changed = True

--- a/website/home/migrations/0109_migrate_image_block_data.py
+++ b/website/home/migrations/0109_migrate_image_block_data.py
@@ -75,8 +75,17 @@ def reverse_migration(apps, schema_editor):
 
             value = block.get("value")
             if isinstance(value, dict) and "image" in value:
-                block["value"] = value["image"]
-                changed = True
+                image_val = value["image"]
+                image_id = None
+                if isinstance(image_val, int):
+                    image_id = image_val
+                elif isinstance(image_val, dict):
+                    possible_id = image_val.get("id")
+                    if isinstance(possible_id, int):
+                        image_id = possible_id
+                if image_id is not None:
+                    block["value"] = image_id
+                    changed = True
 
         if changed:
             cursor.execute(


### PR DESCRIPTION
## Monday Ticket
Please include the Monday ticket ID in the correct format.

**Format:** `WAG-676` (the dash is important)

**Ticket:**

---

## Summary of Changes
Migrates `EnhancedStandardPage` image StreamField blocks to the new `ImageWithLinkBlock` format and updates seeded page definitions accordingly.

**Migration (`0109_migrate_image_block_data.py`):**
- Converts legacy bare integer image block values (`{"type": "image", "value": 42}`) to the correct nested `ImageWithLinkBlock` shape: `{"type": "image", "value": {"image": {"image": 42, ...}, "link": []}}`
- Also handles pre-existing `ImageBlock` dict values (e.g. `{"image": <id>, "alt_text": ..., "decorative": ...}`) by wrapping them into the `ImageWithLinkBlock` structure, preserving existing `ImageBlock` data
- Fixes the reverse migration to correctly extract the image ID from the nested `ImageBlock` dict (`value["image"]["image"]`)

**Seed commands:**
- Updated `dawson_pay_filing_fee.py` and `dawson_find_a_case.py` to emit the correct `ImageWithLinkBlock` value shape, with the image nested under an `image` key and an empty `link` list

---

## Testing Instructions
Provide clear steps for the reviewer to test this change. Please consider any manual steps.

- [ ] Run `python manage.py migrate` and confirm no errors on a database that has existing image blocks in the old format
- [ ] Run the DAWSON seed management commands and confirm pages with image blocks render correctly
- [ ] Link to sandbox (if deployed):
- [ ] Any special accounts, flags, or permissions needed

---

## Post-Deployment Steps (if any)
Run `python manage.py migrate` to apply the data migration converting existing image blocks to the new `ImageWithLinkBlock` format.

---

## Remaining Work (if any)
Please incude any remaining tasks to complete the story.

---

## Reviewer Notes
The migration uses raw SQL to avoid StreamField deserialization issues during the migration itself. It handles two legacy formats: bare integer image IDs and pre-existing `ImageBlock` dicts. Both are correctly wrapped into the `ImageWithLinkBlock` StructBlock shape expected by the updated StreamField definition.

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.