### PR TITLE
using get_file_hash() instead (see notes)

### DIFF
--- a/website/home/management/commands/update_pages.py
+++ b/website/home/management/commands/update_pages.py
@@ -27,6 +27,7 @@ def create_file_hash_for_documents():
 
     for doc in Document.objects.filter(file_hash=""):
         logger.info(f"Generating file hash for document id={doc.id} name='{doc.title}'")
+        """The below method implicitly sets the file's hash if it is empty when it is called."""
         doc.get_file_hash()
 
 
@@ -36,6 +37,7 @@ def create_file_hash_for_images():
 
     for img in Image.objects.filter(file_hash=""):
         logger.info(f"Generating file hash for image id={img.id} name='{img.title}'")
+        """The below method implicitly sets the image's hash if it is empty when it is called."""
         img.get_file_hash()
 
 

--- a/website/home/management/commands/update_pages.py
+++ b/website/home/management/commands/update_pages.py
@@ -27,11 +27,7 @@ def create_file_hash_for_documents():
 
     for doc in Document.objects.filter(file_hash=""):
         logger.info(f"Generating file hash for document id={doc.id} name='{doc.title}'")
-        """The below command uses a private Wagtail API function to set the file hash of the image being
-        worked on. Highlighting this use in case a future version of Wagtail causes this call to be
-        obsolete or to throw errors."""
-        doc._set_file_hash()
-        doc.save(update_fields=["file_hash"])
+        doc.get_file_hash()
 
 
 def create_file_hash_for_images():
@@ -40,11 +36,7 @@ def create_file_hash_for_images():
 
     for img in Image.objects.filter(file_hash=""):
         logger.info(f"Generating file hash for image id={img.id} name='{img.title}'")
-        """The below command uses a private Wagtail API function to set the file hash of the image being
-        worked on. Highlighting this use in case a future version of Wagtail causes this call to be
-        obsolete or to throw errors."""
-        img._set_file_hash()
-        img.save(update_fields=["file_hash"])
+        img.get_file_hash()
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
apparently wagtail's get_file_hash() implicitly sets the hash if it isn't present. So this feels like a safer bet.

More info:
- https://github.com/wagtail/wagtail/blob/main/wagtail/documents/models.py
- https://github.com/wagtail/wagtail/blob/main/wagtail/images/models.py
