### PR TITLE
fall through to github.ref when called via tag push

### DIFF
--- a/.github/workflows/qa_deploy.yml
+++ b/.github/workflows/qa_deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref || 'qa' }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform


### PR DESCRIPTION
In the qa_deploy workflow,  checkout step always deploys the qa branch, regardless of what tag you pushed.  This is because input.ref in a tag-push scenario will always be blank and the default is "qa".   This was a but introduced from my `qa-ready` changes.  

This tweak fixes the issue while still allowing qa *branch* deploys using the qa-ready label.