### PR TITLE
WAG-1255: block CloudFront bucket listing at /files/ 

### DIFF
--- a/infra/modules/app/cloudfront.tf
+++ b/infra/modules/app/cloudfront.tf
@@ -296,22 +296,6 @@ data "aws_iam_policy_document" "s3_policy" {
       values   = [aws_cloudfront_distribution.app.arn]
     }
   }
-
-  statement {
-    actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.private_bucket.arn]
-
-    principals {
-      type        = "Service"
-      identifiers = ["cloudfront.amazonaws.com"]
-    }
-
-    condition {
-      test     = "StringEquals"
-      variable = "AWS:SourceArn"
-      values   = [aws_cloudfront_distribution.app.arn]
-    }
-  }
 }
 
 resource "aws_s3_bucket_policy" "cloudfront_access_policy" {

--- a/website/redirects/pdf_redirect_function.js
+++ b/website/redirects/pdf_redirect_function.js
@@ -8,6 +8,15 @@
             request.uri = request.uri.slice(6);
           }
 
+          // Block bucket-root and directory-style requests so S3 cannot
+          // return a bucket listing if ListBucket is ever re-granted.
+          if (request.uri === "" || request.uri === "/" || request.uri.endsWith("/")) {
+            return {
+              statusCode: 403,
+              statusDescription: "Forbidden"
+            };
+          }
+
           var uri = request.uri;
 
           // Exact path redirects (manual override)


### PR DESCRIPTION
## Monday Ticket
**Format:** `WAG-XXX` (the dash is important)

**Ticket:** WAG-1255

---

## Summary of Changes
Hotfix for a public information disclosure: `https://www.ustaxcourt.gov/files/` currently returns the raw S3 bucket XML listing for `production-ustc-website-assets`.

```
$ curl -sI https://www.ustaxcourt.gov/files/
HTTP/2 200
content-type: application/xml
server: AmazonS3
x-amz-bucket-arn: arn:aws:s3:::production-ustc-website-assets
```

Two changes, defense in depth on both sides of the CloudFront → S3 chain:

- `infra/modules/app/cloudfront.tf` — remove the `s3:ListBucket` statement from the CloudFront S3 bucket policy. OAC-fronted file delivery only needs `s3:GetObject`; the ListBucket grant was what allowed S3 to return the directory listing.
- `website/redirects/pdf_redirect_function.js` — short-circuit any request whose URI (after the `/files/` strip) is empty or ends in `/`, returning a 403 at the edge before it ever reaches S3. This guards against the same bug recurring if the bucket policy ever drifts back.

Targeting `production` since this is a hotfix for a live information-disclosure issue. Will be brought back into `main` separately.

---

## Testing Instructions

- [ ] Deploy branch to sandbox: `make tag tag=sandbox`
- [ ] `curl -sI https://<your-sandbox>-sandbox-web.ustaxcourt.gov/files/` returns **403** (not 200 with `application/xml`/`server: AmazonS3`)
- [ ] `curl -sI https://<your-sandbox>-sandbox-web.ustaxcourt.gov/files/documents/` returns **403**
- [ ] `curl -sI https://<your-sandbox>-sandbox-web.ustaxcourt.gov/files/documents/<some-existing.pdf>` still returns **200** and serves the file
- [ ] One of the documented legacy redirects in `pdf_redirect_function.js` still issues its 301 (e.g. `/documents/Rule-229A.pdf` → `/files/documents/rule-229A.pdf`)
- [ ] Link to sandbox (if deployed):
- [ ] No special accounts, flags, or permissions needed

---

## Post-Deployment Steps (if any)
After production deploy, re-run the reproducer to confirm the fix is live:

```
curl -sI https://www.ustaxcourt.gov/files/
```

Expect `HTTP/2 403` (not `HTTP/2 200` with `server: AmazonS3`). CloudFront cache invalidation should not be needed since the bucket-root response wasn't cacheable, but invalidate `/files/*` if anything looks stale.

---

## Remaining Work (if any)
Follow-up (not in this PR): consider adding a `custom_error_response` block on the distribution to map 403/404 from S3 to a friendly Django error page, so users hitting a missing `/files/...` path see something nicer than raw S3 XML. Skipping in this hotfix to keep scope tight.

---

## Reviewer Notes
- `s3:GetObject` is unchanged, so file delivery is unaffected. The only behavior change for missing keys is that S3 now returns `403` instead of `404` (S3 hides existence without `ListBucket`). The previous response was already raw S3 XML, so end-user impact is minimal.
- The CF function change runs as a viewer-request function, so the 403 is returned at the CloudFront edge — S3 is never contacted for bucket-root or directory-style URIs.