### PR TITLE
WAG-1271: Add e2e test to validate QAT tile link destinations

### DIFF
--- a/website/cypress/e2e/index.spec.cy.ts
+++ b/website/cypress/e2e/index.spec.cy.ts
@@ -40,6 +40,17 @@ describe('index page', () => {
     cy.url().should('include', '/case-related-forms/')
   })
 
+  it('quick access tile links point to destinations other than the home page', () => {
+    cy.url().then((homeUrl) => {
+      cy.get('.cards-grid a').each(($a) => {
+        const href = $a.attr('href')
+        expect(href, 'tile link href should not be empty').to.exist
+        expect(href).to.not.equal(homeUrl)
+        expect(href).to.not.equal('/')
+      })
+    })
+  })
+
   it('search buttons contain text or title attribute for accessibility', () => {
     cy.get('[data-testid="search-button"]').should(($button) => {
 

--- a/website/cypress/e2e/index.spec.cy.ts
+++ b/website/cypress/e2e/index.spec.cy.ts
@@ -42,12 +42,15 @@ describe('index page', () => {
 
   it('quick access tile links point to destinations other than the home page', () => {
     cy.url().then((homeUrl) => {
-      const homePathname = new URL(homeUrl).pathname
+      const homeResolved = new URL(homeUrl)
       cy.get('.cards-grid a').each(($a) => {
         const href = $a.attr('href')
         expect(href, 'tile link href should not be empty').to.be.a('string').and.not.be.empty
         const resolvedUrl = new URL(href!, homeUrl)
-        expect(resolvedUrl.pathname, 'tile link should not point to home page').to.not.equal(homePathname)
+        // Cross-origin links are never the home page; only check pathname for same-origin links
+        if (resolvedUrl.origin === homeResolved.origin) {
+          expect(resolvedUrl.pathname, 'tile link should not point to home page').to.not.equal(homeResolved.pathname)
+        }
       })
     })
   })

--- a/website/cypress/e2e/index.spec.cy.ts
+++ b/website/cypress/e2e/index.spec.cy.ts
@@ -42,11 +42,12 @@ describe('index page', () => {
 
   it('quick access tile links point to destinations other than the home page', () => {
     cy.url().then((homeUrl) => {
+      const homePathname = new URL(homeUrl).pathname
       cy.get('.cards-grid a').each(($a) => {
         const href = $a.attr('href')
-        expect(href, 'tile link href should not be empty').to.exist
-        expect(href).to.not.equal(homeUrl)
-        expect(href).to.not.equal('/')
+        expect(href, 'tile link href should not be empty').to.be.a('string').and.not.be.empty
+        const resolvedUrl = new URL(href!, homeUrl)
+        expect(resolvedUrl.pathname, 'tile link should not point to home page').to.not.equal(homePathname)
       })
     })
   })


### PR DESCRIPTION
## Summary

- Adds a Cypress e2e test to verify that Quick Access Tile (QAT) links on the homepage point to valid destinations
- Ensures no QAT link resolves to the home page itself (either by URL match or `/`), catching misconfigured or placeholder links

## Test plan

- [ ] Run `make test-e2e` locally and confirm the new test passes
- [ ] Verify the test catches a broken link if a QAT card `href` is set to `/` or the home URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)