### PR TITLE
Wag 98 create external links report

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -49,7 +49,7 @@ coverage:
 	. $(VENV) && coverage html -d coverage_html && open coverage_html/index.html
 
 test-e2e:
-	CYPRESS_INCLUDE_ADMIN_VALIDATION=$(if $(filter include-admin,$(args)),true,false) CYPRESS_BASE_URL="$(baseUrl)" CYPRESS_ADMIN_USERNAME="$(value adminUsername)" CYPRESS_ADMIN_PASSWORD="$(value adminPassword)" npx cypress run --browser chrome
+	CYPRESS_INCLUDE_ADMIN_VALIDATION=$(if $(findstring include-admin,$(args)),true,false) CYPRESS_INCLUDE_LOCAL_VALIDATION=$(if $(findstring include-local,$(args)),true,false) CYPRESS_BASE_URL="$(baseUrl)" CYPRESS_ADMIN_USERNAME="$(value adminUsername)" CYPRESS_ADMIN_PASSWORD="$(value adminPassword)" npx cypress run --browser chrome
 
 test-e2e-aws:
 	CYPRESS_ADMIN_USERNAME="$(admin_username)" CYPRESS_ADMIN_PASSWORD="$(admin_password)" \
@@ -64,7 +64,7 @@ test-e2e-aws:
 		$(if $(filter include-admin,$(args)),--include-admin,)
 
 cypress-open:
-	CYPRESS_INCLUDE_ADMIN_VALIDATION=$(if $(filter include-admin,$(args)),true,false) CYPRESS_BASE_URL="$(baseUrl)" CYPRESS_ADMIN_USERNAME="$(value adminUsername)" CYPRESS_ADMIN_PASSWORD="$(value adminPassword)" npx cypress open --browser chrome
+	CYPRESS_INCLUDE_ADMIN_VALIDATION=$(if $(findstring include-admin,$(args)),true,false) CYPRESS_INCLUDE_LOCAL_VALIDATION=$(if $(findstring include-local,$(args)),true,false) CYPRESS_BASE_URL="$(baseUrl)" CYPRESS_ADMIN_USERNAME="$(value adminUsername)" CYPRESS_ADMIN_PASSWORD="$(value adminPassword)" npx cypress open --browser chrome
 
 cypress-open-aws:
 	CYPRESS_ADMIN_USERNAME="$(admin_username)" CYPRESS_ADMIN_PASSWORD="$(admin_password)" \

--- a/website/app/settings/base.py
+++ b/website/app/settings/base.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     "app.role_switcher",
     "django_filters",
     "wagtail_transfer",
+    "wagtail_external_links_report",
 ]
 
 MIDDLEWARE = [
@@ -477,3 +478,5 @@ WAGTAILTRANSFER_LOOKUP_FIELDS = {
     "wagtaildocs.document": ["title", "file_hash"],
     "wagtailimages.image": ["title", "file_hash"],
 }
+
+EXTERNAL_LINKS_REPORT_CLASS = "home.views.CustomExternalLinksReportView"

--- a/website/cypress.config.ts
+++ b/website/cypress.config.ts
@@ -5,7 +5,9 @@ import * as path from "path";
 import * as XLSX from "xlsx";
 
 const includeAdminValidation = process.env.CYPRESS_INCLUDE_ADMIN_VALIDATION === 'true';
+const includeLocalValidation = process.env.CYPRESS_INCLUDE_LOCAL_VALIDATION === 'true';
 const adminValidationSpecPattern = '**/admin*_validation.cy.{js,jsx,ts,tsx}';
+const localValidationSpecPattern = '**/local*cy.{js,jsx,ts,tsx}';
 const baseUrl = process.env.CYPRESS_BASE_URL || 'http://localhost:8000';
 const adminUsername = process.env.CYPRESS_ADMIN_USERNAME || undefined;
 const adminPassword = process.env.CYPRESS_ADMIN_PASSWORD || undefined;
@@ -13,6 +15,17 @@ const env = {
   ...(adminUsername ? { ADMIN_USERNAME: adminUsername } : {}),
   ...(adminPassword ? { ADMIN_PASSWORD: adminPassword } : {}),
 };
+
+function getExcludeSpecPattern() {
+  let result : string[] = [];
+  if (!includeAdminValidation) {
+    result.push(adminValidationSpecPattern);
+  }
+  if (!includeLocalValidation) {
+    result.push(localValidationSpecPattern);
+  }
+  return result;
+}
 
 export default defineConfig({
   e2e: {
@@ -41,8 +54,6 @@ export default defineConfig({
     baseUrl,
     ...(Object.keys(env).length > 0 ? { env } : {}),
     specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
-    excludeSpecPattern: includeAdminValidation
-      ? []
-      : [adminValidationSpecPattern]
+    excludeSpecPattern: getExcludeSpecPattern()
   },
 });

--- a/website/cypress/e2e/local_wag_98_external_link_report.cy.ts
+++ b/website/cypress/e2e/local_wag_98_external_link_report.cy.ts
@@ -7,16 +7,23 @@ describe('WAG-98 External Links Report', () => {
     const externalLinksReportUrl = '/admin/reports/external-links/'
 
     it('verifies that the external links in the External Links Test Page appear in the External Links Report', () => {
+        //Create the test page used by this test if it does not already exist
         cy.exec('. ../.venv/bin/activate && python manage.py create_external_links_report_test_page').then((result) =>
         {
+            //Verify that the test page exists and can be accessed
             cy.request({ url: testPageUrl, followRedirect: false }).then((response) => {
                 expect(response.status, `${testPageUrl} should return 200`).to.eq(200);
             });
 
+            //Access the External Links Report and verify the following:
             cy.adminLogin(ADMIN_USERNAME, ADMIN_PASSWORD);
-
             cy.visit(externalLinksReportUrl);
+            // - The test page verified above shows up in the report
             cy.get('#'+testPageSlug).should(($tr) => {expect($tr).to.have.length(1)});
+            // - The test page's row in report has 21 rows in the subtable
+            // - None of the rows in the subtable for the test page contain the word "internal" (there are a few instances
+            //      of the word "internal" associated with internal links on the test page that should not appear in this
+            //      report)
             cy.get('#'+testPageSlug).first().within(($testPageRowInReport) => {
                 cy.get("tr").should(($rowsForTestPage) => {
                     expect($rowsForTestPage).to.have.length(21);
@@ -24,6 +31,7 @@ describe('WAG-98 External Links Report', () => {
                 });
             })
         }).then((result) => {
+            //Delete the test page used by this test case
             cy.exec('. ../.venv/bin/activate && python manage.py create_external_links_report_test_page --delete');
         })
     });

--- a/website/cypress/e2e/local_wag_98_external_link_report.cy.ts
+++ b/website/cypress/e2e/local_wag_98_external_link_report.cy.ts
@@ -1,0 +1,30 @@
+describe('WAG-98 External Links Report', () => {
+    const ADMIN_USERNAME = Cypress.env('ADMIN_USERNAME') || 'admin';
+    const ADMIN_PASSWORD = Cypress.env('ADMIN_PASSWORD') || 'ustcAdminPW!';
+
+    const testPageSlug = 'external-links-report-test'
+    const testPageUrl = '/'+testPageSlug+'/'
+    const externalLinksReportUrl = '/admin/reports/external-links/'
+
+    it('verifies that the external links in the External Links Test Page appear in the External Links Report', () => {
+        cy.exec('. ../.venv/bin/activate && python manage.py create_external_links_report_test_page').then((result) =>
+        {
+            cy.request({ url: testPageUrl, followRedirect: false }).then((response) => {
+                expect(response.status, `${testPageUrl} should return 200`).to.eq(200);
+            });
+
+            cy.adminLogin(ADMIN_USERNAME, ADMIN_PASSWORD);
+
+            cy.visit(externalLinksReportUrl);
+            cy.get('#'+testPageSlug).should(($tr) => {expect($tr).to.have.length(1)});
+            cy.get('#'+testPageSlug).first().within(($testPageRowInReport) => {
+                cy.get("tr").should(($rowsForTestPage) => {
+                    expect($rowsForTestPage).to.have.length(21);
+                    expect($rowsForTestPage).to.not.contain("internal");
+                });
+            })
+        }).then((result) => {
+            cy.exec('. ../.venv/bin/activate && python manage.py create_external_links_report_test_page --delete');
+        })
+    });
+});

--- a/website/cypress/e2e/local_wag_98_external_link_report.cy.ts
+++ b/website/cypress/e2e/local_wag_98_external_link_report.cy.ts
@@ -6,33 +6,36 @@ describe('WAG-98 External Links Report', () => {
     const testPageUrl = '/'+testPageSlug+'/'
     const externalLinksReportUrl = '/admin/reports/external-links/'
 
-    it('verifies that the external links in the External Links Test Page appear in the External Links Report', () => {
+    before(() => {
         //Create the test page used by this test if it does not already exist
-        cy.exec('. ../.venv/bin/activate && python manage.py create_external_links_report_test_page').then((result) =>
-        {
-            //Verify that the test page exists and can be accessed
-            cy.request({ url: testPageUrl, followRedirect: false }).then((response) => {
-                expect(response.status, `${testPageUrl} should return 200`).to.eq(200);
-            });
+        cy.exec('. ../.venv/bin/activate && python manage.py create_external_links_report_test_page')
+    });
 
-            //Access the External Links Report and verify the following:
-            cy.adminLogin(ADMIN_USERNAME, ADMIN_PASSWORD);
-            cy.visit(externalLinksReportUrl);
-            // - The test page verified above shows up in the report
-            cy.get('#'+testPageSlug).should(($tr) => {expect($tr).to.have.length(1)});
-            // - The test page's row in report has 21 rows in the subtable
-            // - None of the rows in the subtable for the test page contain the word "internal" (there are a few instances
-            //      of the word "internal" associated with internal links on the test page that should not appear in this
-            //      report)
-            cy.get('#'+testPageSlug).first().within(($testPageRowInReport) => {
-                cy.get("tr").should(($rowsForTestPage) => {
-                    expect($rowsForTestPage).to.have.length(21);
-                    expect($rowsForTestPage).to.not.contain("internal");
-                });
-            })
-        }).then((result) => {
-            //Delete the test page used by this test case
-            cy.exec('. ../.venv/bin/activate && python manage.py create_external_links_report_test_page --delete');
+    after(() => {
+        //Delete the test page used by this test case
+        cy.exec('. ../.venv/bin/activate && python manage.py create_external_links_report_test_page --delete');
+    });
+
+    it('verifies that the external links in the External Links Test Page appear in the External Links Report', () => {
+        //Verify that the test page exists and can be accessed
+        cy.request({ url: testPageUrl, followRedirect: false }).then((response) => {
+            expect(response.status, `${testPageUrl} should return 200`).to.eq(200);
+        });
+
+        //Access the External Links Report and verify the following:
+        cy.adminLogin(ADMIN_USERNAME, ADMIN_PASSWORD);
+        cy.visit(externalLinksReportUrl);
+        // - The test page verified above shows up in the report
+        cy.get('#'+testPageSlug).should(($tr) => {expect($tr).to.have.length(1)});
+        // - The test page's row in report has 21 rows in the subtable
+        // - None of the rows in the subtable for the test page contain the word "internal" (there are a few instances
+        //      of the word "internal" associated with internal links on the test page that should not appear in this
+        //      report)
+        cy.get('#'+testPageSlug).first().within(($testPageRowInReport) => {
+            cy.get("tr").should(($rowsForTestPage) => {
+                expect($rowsForTestPage).to.have.length(21);
+                expect($rowsForTestPage).to.not.contain("internal");
+            });
         })
     });
 });

--- a/website/home/management/commands/create_external_links_report_test_page.py
+++ b/website/home/management/commands/create_external_links_report_test_page.py
@@ -1,0 +1,41 @@
+"""
+Management command to create a test page with components containing external links.
+This is for local testing only. Run with:
+    python manage.py create_external_links_report_test_page
+To delete the test page:
+    python manage.py create_external_links_report_test_page --delete
+"""
+
+from django.core.management.base import BaseCommand
+from home.management.commands.pages.external_links_report_test_page import (
+    ExternalLinksReportTestPageInitializer,
+)
+
+
+class Command(BaseCommand):
+    help = "Create a test page with components containing external links for local testing."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--delete",
+            action="store_true",
+            help="Delete the test page instead of creating it.",
+        )
+
+    def handle(self, *args, **options):
+        initializer = ExternalLinksReportTestPageInitializer()
+
+        if options["delete"]:
+            initializer.delete()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "External Links Report test page deleted (if it existed)."
+                )
+            )
+        else:
+            initializer.create()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "External Links Report test page created. Visit /external-links-report-test/ to view it."
+                )
+            )

--- a/website/home/management/commands/pages/external_links_report_test_page.py
+++ b/website/home/management/commands/pages/external_links_report_test_page.py
@@ -1,0 +1,470 @@
+"""
+Test page initializer for validating that external links in different components
+appear in the External Links Report.
+This creates an EnhancedStandardPage with components that can hold an external link.
+For local testing only.
+"""
+
+from wagtail.models import Page
+from home.management.commands.pages.page_initializer import PageInitializer
+from home.models import EnhancedStandardPage
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalLinksReportTestPageInitializer(PageInitializer):
+    """
+    Creates a test page with components containing an external link.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.slug = "external-links-report-test"
+
+    def create(self):
+        try:
+            home_page = Page.objects.get(slug="home")
+        except Page.DoesNotExist:
+            logger.info("Root page (home) does not exist.")
+            return
+
+        self.create_page_info(home_page)
+
+    def create_page_info(self, home_page):
+        title = "External Links Report Test Page"
+
+        if Page.objects.filter(slug=self.slug).exists():
+            logger.info(f"- {title} page already exists.")
+            return
+
+        logger.info(f"Creating the '{title}' page.")
+
+        body = [
+            {
+                "type": "button",
+                "value": {
+                    "icon": None,
+                    "text": "PDF Button",
+                    "url": [
+                        {
+                            "type": "internal_pdf",
+                            "value": 708,
+                            "id": "8aa40708-d47d-41e6-a68c-33c190c7ddea",
+                        }
+                    ],
+                    "style": "primary",
+                    "button_hover": True,
+                },
+                "id": "156a2bcd-5183-4557-bb6f-ac82514ad7fa",
+            },
+            {
+                "type": "button",
+                "value": {
+                    "icon": None,
+                    "text": "Internal Button",
+                    "url": [
+                        {
+                            "type": "internal_page",
+                            "value": 6,
+                            "id": "3b8629dd-804c-4368-a58d-86ba94041410",
+                        }
+                    ],
+                    "style": "primary",
+                    "button_hover": True,
+                },
+                "id": "0a70f3ff-b8ac-499c-a07e-73c9fea7f801",
+            },
+            {
+                "type": "button",
+                "value": {
+                    "icon": None,
+                    "text": "External Button",
+                    "url": [
+                        {
+                            "type": "external_url",
+                            "value": "https://www.bing.com/",
+                            "id": "a8f047ac-8af3-431c-a295-23ee03f88cd7",
+                        }
+                    ],
+                    "style": "primary",
+                    "button_hover": True,
+                },
+                "id": "50c4d553-7c32-453e-a705-c244874ddf63",
+            },
+            {
+                "type": "quick_access_tiles",
+                "value": {
+                    "tiles_hover_enabled": True,
+                    "icon_position": "desktop_top_mobile_left",
+                    "tiles": [
+                        {
+                            "type": "item",
+                            "value": {
+                                "title": "External Link in Quick Access Tile",
+                                "description": '<p data-block-key="qd375">This leads to an external link</p>',
+                                "icon": {"svg_file": 714},
+                                "content_alignment": "center",
+                                "link": [
+                                    {
+                                        "type": "external_url",
+                                        "value": "https://www.google.com",
+                                        "id": "b3972343-dec1-4053-9de6-fcf4765ab9a6",
+                                    }
+                                ],
+                            },
+                            "id": "d8c58746-ec7a-439f-a530-a9bc9d6db87d",
+                        },
+                        {
+                            "type": "item",
+                            "value": {
+                                "title": "Internal Link in Quick Access Tile",
+                                "description": '<p data-block-key="qd375">This leads to an internal/related link</p>',
+                                "icon": {"svg_file": 714},
+                                "content_alignment": "center",
+                                "link": [
+                                    {
+                                        "type": "related_page",
+                                        "value": 6,
+                                        "id": "4b34b7d5-21c0-45d4-8026-dee0d82b974b",
+                                    }
+                                ],
+                            },
+                            "id": "dccecb35-9c20-4d6d-9564-67846dce9906",
+                        },
+                    ],
+                },
+                "id": "5664774c-265d-4242-b49a-95d003f2f7ce",
+            },
+            {
+                "type": "paragraph",
+                "value": '<p data-block-key="1wv5f">This is to test the <a href="#btn-6-accordian">Anchor Link in Paragraph</a> on page</p><p data-block-key="d4osk">This is to test the <a href="https://ustaxcourt.gov/court-fees/#btn-4-accordian">Anchor Link in Paragraph on different page</a></p><p data-block-key="2i48b">Checking <a linktype="page" id="6">Internal Link</a></p><p data-block-key="cljnb">Checking <a href="https://www.youtube.com/?themeRefresh=1">External Link in Paragraph</a></p>',
+                "id": "9112521b-26b2-4177-b95f-cf49cb4dffe7",
+            },
+            {
+                "type": "photo_dedication",
+                "value": {
+                    "image_position": "left",
+                    "title": "This is a photo + text to see if anchor works",
+                    "photo": 31,
+                    "alt_text": "This is an image",
+                    "paragraph_text": '<p data-block-key="1h5e8">Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.</p><p data-block-key="8coe5">Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.</p><p data-block-key="2qon5">Lorem ipsum dolor sit amet consectetur adipiscing elit. Quisque faucibus ex sapien vitae pellentesque sem placerat. In id cursus mi pretium tellus duis convallis. Tempus leo eu aenean sed diam urna tempor. Pulvinar vivamus fringilla lacus nec metus bibendum egestas. Iaculis massa nisl malesuada lacinia integer nunc posuere. Ut hendrerit semper vel class aptent taciti sociosqu. Ad litora torquent per conubia nostra inceptos himenaeos.</p><p data-block-key="fcof1"><a href="https://guides.18f.org/">External Link in Paragraph of Photo + Text</a></p>',
+                    "link": [],
+                },
+                "id": "eb7ef844-0e52-45a2-923f-430a4e87dffe",
+            },
+            {
+                "type": "accordian",
+                "value": {
+                    "title": "This is an accordion",
+                    "description": [
+                        {
+                            "type": "prose",
+                            "value": '<p data-block-key="byr0k">Text that goes into accordian <a href="https://webaim.org/resources/contrastchecker/">External Link in Prose of Accordian Block</a></p>',
+                            "id": "aab4950a-e9f0-45d4-9890-fe1a78e9df77",
+                        }
+                    ],
+                    "default_to_open": False,
+                },
+                "id": "d97b487d-3c30-423f-9f42-a0b0ccf869bb",
+            },
+            {
+                "type": "card_tiles",
+                "value": {
+                    "tiles": [
+                        {
+                            "type": "item",
+                            "value": {
+                                "icon": 718,
+                                "icon_direction": "top",
+                                "card_header": "Internal Link in Card Tile",
+                                "link": [
+                                    {
+                                        "type": "internal_page",
+                                        "value": 3,
+                                        "id": "4b30362d-0cf0-486a-ac36-f9bbe5475c81",
+                                    }
+                                ],
+                                "card_hover": True,
+                            },
+                            "id": "7517df62-c468-4a07-b47c-85740af410ba",
+                        },
+                        {
+                            "type": "item",
+                            "value": {
+                                "icon": 718,
+                                "icon_direction": "top",
+                                "card_header": "External Link in Card Tile",
+                                "link": [
+                                    {
+                                        "type": "external_url",
+                                        "value": "https://www.firefox.com/en-US/?redirect_source=mozilla-org",
+                                        "id": "a784cc9c-adc5-4eac-8f2d-d0350351d479",
+                                    }
+                                ],
+                                "card_hover": True,
+                            },
+                            "id": "f19d1632-330e-4797-814d-43bbc5d35ddf",
+                        },
+                        {
+                            "type": "item",
+                            "value": {
+                                "icon": 718,
+                                "icon_direction": "top",
+                                "card_header": "Anchor",
+                                "link": [
+                                    {
+                                        "type": "anchor_page",
+                                        "value": {
+                                            "breadcrumb_title": "Anchor Link in Card Tile",
+                                            "body": [
+                                                {
+                                                    "type": "paragraph",
+                                                    "value": '<p data-block-key="bwn6r">hello there</p>',
+                                                    "id": "58134c3f-b5f9-4bce-b16d-677d370db29a",
+                                                }
+                                            ],
+                                        },
+                                        "id": "537ebd18-b7cf-4867-8559-234ab21fc22e",
+                                    }
+                                ],
+                                "card_hover": True,
+                            },
+                            "id": "7937eef6-88be-4b99-b750-e57f66181a72",
+                        },
+                    ],
+                    "default_content": [],
+                },
+                "id": "905b8804-60d7-49b4-93e5-79e77e82339d",
+            },
+            {
+                "type": "grid",
+                "value": {
+                    "columns": "1",
+                    "width": "full",
+                    "gridStyle": "styled",
+                    "cells": [
+                        {
+                            "type": "item",
+                            "value": {
+                                "header": "This is a grid",
+                                "header_color": "#f1f9fc",
+                                "caption": '<p data-block-key="7lenn">this is a caption for grid. <a href="https://ustc-isd.monday.com/auth/login_monday/email_password">External Link in Grid Cell Caption</a></p>',
+                                "italic_caption": False,
+                                "body": [
+                                    {
+                                        "type": "prose",
+                                        "value": '<p data-block-key="ipqmw"><a href="https://www.section508.gov/training/web-software/andi-training-videos/">External Link in Grid Cell Body</a></p>',
+                                        "id": "3a05d75c-7194-4f44-801b-ed9e3ae53966",
+                                    }
+                                ],
+                            },
+                            "id": "92da3bc3-7cbb-4c5e-b7fc-ab453128e94d",
+                        }
+                    ],
+                },
+                "id": "d409a5b7-d189-4aef-ab4f-5d24145f96cb",
+            },
+            {
+                "type": "enhanced_table",
+                "value": {
+                    "header": "This is a table",
+                    "caption": '<p data-block-key="l43en">A space for the caption</p>',
+                    "caption_location": "top",
+                    "style": "styled",
+                    "fixed": False,
+                    "table": {
+                        "columns": [{"type": "components", "heading": "Checking Link"}],
+                        "rows": [
+                            {
+                                "values": [
+                                    [
+                                        {
+                                            "type": "text",
+                                            "value": '<p data-block-key="805i1"><a href="https://www.ssa.gov/accessibility/andi/help/install.html">External Link in Enhanced Table Cell</a></p>',
+                                            "id": "c884132b-c514-46e6-abdb-9f97df3ffdf1",
+                                        }
+                                    ]
+                                ]
+                            }
+                        ],
+                        "caption": "",
+                    },
+                },
+                "id": "5eeeda81-a38b-42d5-a85a-bfc00b61af42",
+            },
+            {
+                "type": "alert",
+                "value": {
+                    "alert_type": "info",
+                    "content": '<p data-block-key="iyt9o"><a href="https://www.google.com">External Link in Alert</a></p>',
+                },
+                "id": "5f48de91-1cbe-4149-9020-3cc546798032",
+            },
+            {
+                "type": "callout",
+                "value": {
+                    "heading": "callout test",
+                    "text": '<p data-block-key="xa6hs"><a href="https://www.google.com">External Link in Callout Block</a></p>',
+                    "callout_type": "info",
+                },
+                "id": "e00f047d-eeb8-4875-9ac9-8d43efba1462",
+            },
+            {
+                "type": "embedded_video",
+                "value": {
+                    "title": "",
+                    "description": '<p data-block-key="y04su"><a href="https://www.youtube.com">External Link in Video Embed</a></p>',
+                    "video_url": "https://www.youtube.com/embed/sF80I-TQiW0",
+                    "text_location": "below",
+                },
+                "id": "578d1ed5-aebe-4c99-a51d-2a61aff6f047",
+            },
+            {
+                "type": "list",
+                "value": {
+                    "list_type": "ordered",
+                    "items": [
+                        {
+                            "type": "item",
+                            "value": {
+                                "text": '<p data-block-key="nvpop"><a href="https://www.google.com">External Link in List Item</a></p>',
+                                "image": {
+                                    "image": None,
+                                    "alt_text": None,
+                                    "decorative": None,
+                                },
+                                "nested_list": [],
+                            },
+                            "id": "2c0c914f-0c47-406f-ba1c-48d106989e10",
+                        }
+                    ],
+                },
+                "id": "264b3299-abad-4994-b5b6-8847068ca064",
+            },
+            {
+                "type": "questionanswers",
+                "value": [
+                    {
+                        "type": "item",
+                        "value": {
+                            "question": "Q1",
+                            "answer": '<p data-block-key="jsnxn"><a href="https://www.google.com">External Link in Q&amp;A</a></p>',
+                            "anchortag": "QA1",
+                        },
+                        "id": "06f8c64e-7985-4141-be19-0d141db5bdc4",
+                    },
+                    {
+                        "type": "item",
+                        "value": {
+                            "question": "Q2",
+                            "answer": '<p data-block-key="i1xjt"><a href="https://www.google.com">https://www.google.com</a></p>',
+                            "anchortag": "QA2",
+                        },
+                        "id": "3a0a087c-cbc4-40d4-b9dd-19a34820681b",
+                    },
+                    {
+                        "type": "item",
+                        "value": {
+                            "question": "Q3",
+                            "answer": '<p data-block-key="i1xjt"><a href="http://www.yahoo.com">http://www.yahoo.com External Link in Q&amp;A with URL in text</a></p>',
+                            "anchortag": "QA3",
+                        },
+                        "id": "4390fba0-5624-461e-a3ac-bf005dd1c001",
+                    },
+                ],
+                "id": "df2f2ede-33b9-402d-8cb0-6d76f62b4a94",
+            },
+            {
+                "type": "table",
+                "value": {
+                    "columns": [{"type": "text", "heading": "Table Checking Link"}],
+                    "rows": [
+                        {
+                            "values": [
+                                '<p data-block-key="xqdfh"><a href="https://www.msn.com">External Link in Table Cell</a></p>'
+                            ]
+                        }
+                    ],
+                    "caption": "",
+                },
+                "id": "5b5d8ffe-0e8d-4a29-8c9b-6a81b9f00938",
+            },
+            {
+                "type": "unstyled_table",
+                "value": {
+                    "columns": [
+                        {"type": "text", "heading": "Unstyled table checking link"}
+                    ],
+                    "rows": [
+                        {
+                            "values": [
+                                '<p data-block-key="et0ky"><a href="https://www.google.com">External Link in Unstyled Table Cell</a></p>'
+                            ]
+                        }
+                    ],
+                    "caption": "",
+                },
+                "id": "07fc1d94-ef58-4c72-93ef-dff89a8d187e",
+            },
+            {
+                "type": "links",
+                "value": {
+                    "class": "indented",
+                    "links": [
+                        {
+                            "type": "item",
+                            "value": {
+                                "title": "External Link in List of Links",
+                                "icon": "",
+                                "document": None,
+                                "video": None,
+                                "url": "www.google.com",
+                                "text_only": False,
+                            },
+                            "id": "5c58620c-df4a-4334-8dc3-6ca8938d4603",
+                        }
+                    ],
+                },
+                "id": "c01d118a-60aa-475c-87b1-ee1cd05d3098",
+            },
+            {
+                "type": "image",
+                "value": {
+                    "image": {
+                        "image": 30,
+                        "alt_text": "External Link in Image",
+                        "decorative": False,
+                    },
+                    "link": [
+                        {
+                            "type": "external_url",
+                            "value": "https://www.google.com",
+                            "id": "9e652d82-488d-4d6a-b25b-6e4edcec0f0c",
+                        }
+                    ],
+                },
+                "id": "735b91e3-bca6-4559-969f-b494225b6f94",
+            },
+        ]
+
+        home_page.add_child(
+            instance=EnhancedStandardPage(
+                title=title,
+                slug=self.slug,
+                seo_title=title,
+                search_description="Test page for External Links Report",
+                body=body,
+            )
+        )
+
+        logger.info(f"Created the '{title}' page.")
+
+    def delete(self):
+        """Delete the test page if it exists."""
+        try:
+            page = Page.objects.get(slug=self.slug)
+            page.delete()
+            logger.info(f"Deleted test page with slug '{self.slug}'.")
+        except Page.DoesNotExist:
+            logger.info(f"Test page with slug '{self.slug}' does not exist.")

--- a/website/home/templates/home/custom_external_links_report_results.html
+++ b/website/home/templates/home/custom_external_links_report_results.html
@@ -16,10 +16,19 @@
             padding-inline-start: 0 !important;
             padding-block: calc(0.5em * var(--w-density-factor));
         }
+        .inner-table td a {
+            word-break: break-word;
+            overflow-wrap: break-word;
+            white-space: normal;
+            display: inline-block; /* Helps with wrapping in some browsers */
+        }
     </style>
     <table class="listing {% block table_classname %}{% endblock %}">
         <col width="20%" />
-        <col width="80%" />
+        <col width="10%" />
+        <col width="10%" />
+        <col width="30%" />
+        <col width="30%" />
         <thead>
             {% block post_parent_page_headers %}
                 <tr class="table-headers">
@@ -50,7 +59,7 @@
             {% for page in pages %}
                 {% page_permissions page as page_perms %}
                 <tr class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}" id="{{ page.slug }}">
-                    <td class="title" valign="top" data-listing-page-title colspan="2">
+                    <td class="title" valign="top" data-listing-page-title colspan="2" width="40%">
                         {% block page_title %}
                             {% i18n_enabled as show_locale_labels %}
                             {% include "wagtailadmin/pages/listing/_page_title_explore.html" with show_locale_labels=show_locale_labels %}
@@ -60,7 +69,7 @@
                         {{ page.slug }}
                     </td>
                     <td colspan="2">
-                        <table width="100%" class="inner-table">
+                        <table width="100%" class="inner-table" table-layout="fixed">
                             <col width="30%" />
                             <col width="70%" />
                             {% for link in page.external_links %}

--- a/website/home/templates/home/custom_external_links_report_results.html
+++ b/website/home/templates/home/custom_external_links_report_results.html
@@ -49,7 +49,7 @@
         <tbody>
             {% for page in pages %}
                 {% page_permissions page as page_perms %}
-                <tr class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}">
+                <tr class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}" id="{{ page.slug }}">
                     <td class="title" valign="top" data-listing-page-title colspan="2">
                         {% block page_title %}
                             {% i18n_enabled as show_locale_labels %}

--- a/website/home/templates/home/custom_external_links_report_results.html
+++ b/website/home/templates/home/custom_external_links_report_results.html
@@ -1,0 +1,90 @@
+{% extends "wagtailadmin/reports/base_page_report_results.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block results %}
+    <style>
+        table.listing td:has(.inner-table) {
+            padding-block: 0;
+        }
+        .inner-table tr:first-child {
+            border-top: none !important;
+        }
+        .inner-table tbody:last-child {
+            border-bottom: none !important;
+        }
+        .inner-table td {
+            padding-inline-start: 0 !important;
+            padding-block: calc(0.5em * var(--w-density-factor));
+        }
+    </style>
+    <table class="listing {% block table_classname %}{% endblock %}">
+        <col width="20%" />
+        <col width="80%" />
+        <thead>
+            {% block post_parent_page_headers %}
+                <tr class="table-headers">
+                    <th class="title" colspan="2">
+                        Source Page Name
+                        {% block extra_columns %}
+                        {% endblock %}
+                    </th>
+                    <th>Source Slug</th>
+                    <th colspan="2">
+                        <table width="100%" class="inner-table">
+                            <col width="30%" />
+                            <col width="70%" />
+                                <tr>
+                                    <td>
+                                        Link Label
+                                    </td>
+                                    <td>
+                                        Link Destination
+                                    </td>
+                                </tr>
+                        </table>
+                    </th>
+                </tr>
+            {% endblock %}
+        </thead>
+        <tbody>
+            {% for page in pages %}
+                {% page_permissions page as page_perms %}
+                <tr class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}">
+                    <td class="title" valign="top" data-listing-page-title colspan="2">
+                        {% block page_title %}
+                            {% i18n_enabled as show_locale_labels %}
+                            {% include "wagtailadmin/pages/listing/_page_title_explore.html" with show_locale_labels=show_locale_labels %}
+                        {% endblock %}
+                    </td>
+                    <td>
+                        {{ page.slug }}
+                    </td>
+                    <td colspan="2">
+                        <table width="100%" class="inner-table">
+                            <col width="30%" />
+                            <col width="70%" />
+                            {% for link in page.external_links %}
+                                <tr>
+                                    <td>
+                                        {% if link.text != link.url %}
+                                            {{ link.text }}
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <a href="{{ link.url }}" target="_blank">{{ link.url }}</a>
+                                    </td>
+                                </tr>
+                                {% empty %}
+                                <tr>
+                                    <td colspan="2">
+                                        <em>No external links</em>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </table>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}

--- a/website/home/templates/home/custom_external_links_report_results.html
+++ b/website/home/templates/home/custom_external_links_report_results.html
@@ -66,9 +66,7 @@
                             {% for link in page.external_links %}
                                 <tr>
                                     <td>
-                                        {% if link.text != link.url %}
-                                            {{ link.text }}
-                                        {% endif %}
+                                        {{ link.text }}
                                     </td>
                                     <td>
                                         <a href="{{ link.url }}" target="_blank">{{ link.url }}</a>

--- a/website/home/utils/custom_link_extractor.py
+++ b/website/home/utils/custom_link_extractor.py
@@ -1,0 +1,25 @@
+from wagtail_external_links_report.utils import LinkExtractor
+from bs4 import BeautifulSoup
+from wagtail.rich_text import RichText
+
+
+class CustomLinkExtractor(LinkExtractor):
+    def extract_from_value(self, value):
+        """Recursively extract links depending on value type."""
+        links = []
+
+        if isinstance(value, RichText):
+            html = value.source
+            soup = BeautifulSoup(html, "html.parser")
+            for a in soup.find_all("a", href=True):
+                href = a["href"]
+                if not href.startswith("mailto:") and not href.startswith("tel:"):
+                    links.append(
+                        {
+                            "text": a.get_text(strip=True),
+                            "url": href,
+                        }
+                    )
+            return links
+        else:
+            return super().extract_from_value(value)

--- a/website/home/utils/custom_link_extractor.py
+++ b/website/home/utils/custom_link_extractor.py
@@ -13,7 +13,11 @@ class CustomLinkExtractor(LinkExtractor):
             soup = BeautifulSoup(html, "html.parser")
             for a in soup.find_all("a", href=True):
                 href = a["href"]
-                if not href.startswith("mailto:") and not href.startswith("tel:"):
+                if (
+                    not href.startswith("mailto:")
+                    and not href.startswith("tel:")
+                    and not href.startswith("#")
+                ):
                     links.append(
                         {
                             "text": a.get_text(strip=True),

--- a/website/home/utils/custom_link_extractor.py
+++ b/website/home/utils/custom_link_extractor.py
@@ -2,19 +2,52 @@ from wagtail_external_links_report.utils import LinkExtractor
 from bs4 import BeautifulSoup
 from wagtail.rich_text import RichText
 from wagtail.contrib.typed_table_block.blocks import TypedTable
+from home.models.custom_blocks.button import ButtonBlock
+from home.blocks import QuickAccessTileBlock
+from home.models.pages.enhanced_standard import CardTileBlock
+from home.models.custom_blocks.image_with_link import ImageWithLinkBlock
+from wagtail.blocks import StructValue
 
 
 class CustomLinkExtractor(LinkExtractor):
+    def _get_external_link_with_text_from_attribute(value, text_attribute):
+        links = []
+        if value["url"]:
+            for child in value["url"]:
+                if hasattr(child, "block_type") and child.block_type == "external_url":
+                    links.extend({"text": value[text_attribute], "url": child.value})
+
+        return links
+
     def extract_from_value(self, value):
         """Recursively extract links depending on value type."""
         links = []
 
+        if isinstance(value, StructValue) and isinstance(value, ButtonBlock):
+            links.extend(self._get_external_link_with_text_from_attribute("text"))
+            return links
+
+        if isinstance(value, StructValue) and isinstance(value, QuickAccessTileBlock):
+            links.extend(self._get_external_link_with_text_from_attribute("title"))
+            return links
+
+        if isinstance(value, StructValue) and isinstance(value, CardTileBlock):
+            links.extend(
+                self._get_external_link_with_text_from_attribute("card_header")
+            )
+            return links
+
+        if isinstance(value, StructValue) and isinstance(value, ImageWithLinkBlock):
+            links.extend(self._get_external_link_with_text_from_attribute("image"))
+            return links
+
         # Handles external links in Enhanced Tables, Styled Tables, and Unstyled Tables
-        # Other custom handlers are called by similar logic in the base LinkExtractor's
-        # extract_from_value() method.
-        for block_cls, handler in self.custom_handlers.items():
-            if isinstance(value, TypedTable) and isinstance(value, block_cls):
-                return handler(value)
+        if isinstance(value, TypedTable):
+            for row in value.rows:
+                for cell in row:
+                    links.extend(self.extract_from_value(cell.value))
+
+            return links
 
         if isinstance(value, RichText):
             html = value.source

--- a/website/home/utils/custom_link_extractor.py
+++ b/website/home/utils/custom_link_extractor.py
@@ -9,6 +9,9 @@ class CustomLinkExtractor(LinkExtractor):
         """Recursively extract links depending on value type."""
         links = []
 
+        # Handles external links in Enhanced Tables, Styled Tables, and Unstyled Tables
+        # Other custom handlers are called by similar logic in the base LinkExtractor's
+        # extract_from_value() method.
         for block_cls, handler in self.custom_handlers.items():
             if isinstance(value, TypedTable) and isinstance(value, block_cls):
                 return handler(value)
@@ -38,6 +41,7 @@ class CustomLinkExtractor(LinkExtractor):
             and value["url"] is not None
             and isinstance(value["url"], str)
         ):
+            # Handles external links in a List of Links component
             links.append({"text": value["title"], "url": value["url"]})
             return links
         else:

--- a/website/home/utils/custom_link_extractor.py
+++ b/website/home/utils/custom_link_extractor.py
@@ -1,12 +1,17 @@
 from wagtail_external_links_report.utils import LinkExtractor
 from bs4 import BeautifulSoup
 from wagtail.rich_text import RichText
+from wagtail.contrib.typed_table_block.blocks import TypedTable
 
 
 class CustomLinkExtractor(LinkExtractor):
     def extract_from_value(self, value):
         """Recursively extract links depending on value type."""
         links = []
+
+        for block_cls, handler in self.custom_handlers.items():
+            if isinstance(value, TypedTable) and isinstance(value, block_cls):
+                return handler(value)
 
         if isinstance(value, RichText):
             html = value.source
@@ -24,6 +29,16 @@ class CustomLinkExtractor(LinkExtractor):
                             "url": href,
                         }
                     )
+            return links
+        elif (
+            isinstance(value, dict)
+            and "title" in value
+            and "url" in value
+            and value["title"] is not None
+            and value["url"] is not None
+            and isinstance(value["url"], str)
+        ):
+            links.append({"text": value["title"], "url": value["url"]})
             return links
         else:
             return super().extract_from_value(value)

--- a/website/home/views.py
+++ b/website/home/views.py
@@ -494,6 +494,12 @@ class CustomExternalLinksReportView(ExternalLinksReportView):
     results_template_name = "home/custom_external_links_report_results.html"
     page_title = "External Links"
     list_export = ["title", "slug", "link_text", "link_url"]
+    export_headings = {
+        "title": "Source Page Name",
+        "slug": "Source Slug",
+        "link_text": "Link Label",
+        "link_url": "Link Destination",
+    }
 
     def get_extractor(self):
         return CustomLinkExtractor()

--- a/website/home/views.py
+++ b/website/home/views.py
@@ -16,6 +16,7 @@ from django.utils.html import format_html
 from django.utils import timezone
 from wagtail_external_links_report.views import ExternalLinksReportView
 from home.utils.custom_link_extractor import CustomLinkExtractor
+from wagtail.admin.views.generic.base import BaseListingView
 
 
 class NewsItemReportFilterSet(WagtailFilterSet):
@@ -492,6 +493,33 @@ PDF_CHOOSER_VIEWSET = PDFChooserViewSet("pdf_chooser")
 class CustomExternalLinksReportView(ExternalLinksReportView):
     results_template_name = "home/custom_external_links_report_results.html"
     page_title = "External Links"
+    list_export = ["title", "slug", "link_text", "link_url"]
 
     def get_extractor(self):
         return CustomLinkExtractor()
+
+    def get_context_data(self, **kwargs):
+        context = BaseListingView.get_context_data(self, **kwargs)
+        extractor = self.get_extractor()
+
+        for page in context["object_list"]:
+            page.external_links = extractor.extract_from_page(page)
+
+        if self.is_export:
+            context["object_list"] = self.export_rows(context["object_list"])
+
+        return context
+
+    def export_rows(self, page_list):
+        rows = []
+        for page in page_list:
+            for link in page.external_links:
+                rows.append(
+                    {
+                        "title": page.title,
+                        "slug": page.slug,
+                        "link_text": link["text"],
+                        "link_url": link["url"],
+                    }
+                )
+        return rows

--- a/website/home/views.py
+++ b/website/home/views.py
@@ -544,21 +544,22 @@ class CustomExternalLinksReportView(ExternalLinksReportView):
             for row in value["table"].rows:
                 for cell in row:
                     for child in cell.value:
-                        html = child.value.source
-                        soup = BeautifulSoup(html, "html.parser")
-                        for a in soup.find_all("a", href=True):
-                            href = a["href"]
-                            if (
-                                not href.startswith("mailto:")
-                                and not href.startswith("tel:")
-                                and not href.startswith("#")
-                            ):
-                                links.append(
-                                    {
-                                        "text": a.get_text(strip=True),
-                                        "url": href,
-                                    }
-                                )
+                        if hasattr(child.value, "source"):
+                            html = child.value.source
+                            soup = BeautifulSoup(html, "html.parser")
+                            for a in soup.find_all("a", href=True):
+                                href = a["href"]
+                                if (
+                                    not href.startswith("mailto:")
+                                    and not href.startswith("tel:")
+                                    and not href.startswith("#")
+                                ):
+                                    links.append(
+                                        {
+                                            "text": a.get_text(strip=True),
+                                            "url": href,
+                                        }
+                                    )
 
         return links
 

--- a/website/home/views.py
+++ b/website/home/views.py
@@ -16,6 +16,12 @@ from django.utils.html import format_html
 from django.utils import timezone
 from wagtail_external_links_report.views import ExternalLinksReportView
 from home.utils.custom_link_extractor import CustomLinkExtractor
+from home.models.custom_blocks.button import ButtonBlock
+from home.blocks import QuickAccessTileBlock
+from home.models.pages.enhanced_standard import CardTileBlock, TableListBlock
+from wagtail.contrib.typed_table_block.blocks import TypedTable
+from home.models.custom_blocks.image_with_link import ImageWithLinkBlock
+from bs4 import BeautifulSoup
 
 
 class NewsItemReportFilterSet(WagtailFilterSet):
@@ -494,4 +500,95 @@ class CustomExternalLinksReportView(ExternalLinksReportView):
     page_title = "External Links"
 
     def get_extractor(self):
-        return CustomLinkExtractor()
+        return CustomLinkExtractor(
+            custom_handlers={
+                ButtonBlock: self.extract_from_button_block,
+                QuickAccessTileBlock: self.extract_from_quick_access_tile_block,
+                CardTileBlock: self.extract_from_card_tile_block,
+                TableListBlock: self.extract_from_table_list_block,
+                TypedTable: self.extract_from_typed_table_block,
+                ImageWithLinkBlock: self.extract_from_image_with_link_block,
+            }
+        )
+
+    def extract_from_button_block(self, value):
+        links = []
+        if value["url"]:
+            for child in value["url"]:
+                if hasattr(child, "block_type") and child.block_type == "external_url":
+                    links.append({"text": value["text"], "url": child.value})
+
+        return links
+
+    def extract_from_quick_access_tile_block(self, value):
+        links = []
+        if value["link"]:
+            for child in value["link"]:
+                if hasattr(child, "block_type") and child.block_type == "external_url":
+                    links.append({"text": value["title"], "url": child.value})
+
+        return links
+
+    def extract_from_card_tile_block(self, value):
+        links = []
+        if value["link"]:
+            for child in value["link"]:
+                if hasattr(child, "block_type") and child.block_type == "external_url":
+                    links.append({"text": value["card_header"], "url": child.value})
+
+        return links
+
+    def extract_from_table_list_block(self, value):
+        links = []
+        if value["table"]:
+            for row in value["table"].rows:
+                for cell in row:
+                    for child in cell.value:
+                        html = child.value.source
+                        soup = BeautifulSoup(html, "html.parser")
+                        for a in soup.find_all("a", href=True):
+                            href = a["href"]
+                            if (
+                                not href.startswith("mailto:")
+                                and not href.startswith("tel:")
+                                and not href.startswith("#")
+                            ):
+                                links.append(
+                                    {
+                                        "text": a.get_text(strip=True),
+                                        "url": href,
+                                    }
+                                )
+
+        return links
+
+    def extract_from_typed_table_block(self, value):
+        links = []
+        for row in value.rows:
+            for cell in row:
+                html = cell.value.source
+                soup = BeautifulSoup(html, "html.parser")
+                for a in soup.find_all("a", href=True):
+                    href = a["href"]
+                    if (
+                        not href.startswith("mailto:")
+                        and not href.startswith("tel:")
+                        and not href.startswith("#")
+                    ):
+                        links.append(
+                            {
+                                "text": a.get_text(strip=True),
+                                "url": href,
+                            }
+                        )
+
+        return links
+
+    def extract_from_image_with_link_block(self, value):
+        links = []
+        if value["link"]:
+            for child in value["link"]:
+                if hasattr(child, "block_type") and child.block_type == "external_url":
+                    links.append({"text": value["image"].title, "url": child.value})
+
+        return links

--- a/website/home/views.py
+++ b/website/home/views.py
@@ -16,12 +16,6 @@ from django.utils.html import format_html
 from django.utils import timezone
 from wagtail_external_links_report.views import ExternalLinksReportView
 from home.utils.custom_link_extractor import CustomLinkExtractor
-from home.models.custom_blocks.button import ButtonBlock
-from home.blocks import QuickAccessTileBlock
-from home.models.pages.enhanced_standard import CardTileBlock, TableListBlock
-from wagtail.contrib.typed_table_block.blocks import TypedTable
-from home.models.custom_blocks.image_with_link import ImageWithLinkBlock
-from bs4 import BeautifulSoup
 
 
 class NewsItemReportFilterSet(WagtailFilterSet):
@@ -500,96 +494,4 @@ class CustomExternalLinksReportView(ExternalLinksReportView):
     page_title = "External Links"
 
     def get_extractor(self):
-        return CustomLinkExtractor(
-            custom_handlers={
-                ButtonBlock: self.extract_from_button_block,
-                QuickAccessTileBlock: self.extract_from_quick_access_tile_block,
-                CardTileBlock: self.extract_from_card_tile_block,
-                TableListBlock: self.extract_from_table_list_block,
-                TypedTable: self.extract_from_typed_table_block,
-                ImageWithLinkBlock: self.extract_from_image_with_link_block,
-            }
-        )
-
-    def extract_from_button_block(self, value):
-        links = []
-        if value["url"]:
-            for child in value["url"]:
-                if hasattr(child, "block_type") and child.block_type == "external_url":
-                    links.append({"text": value["text"], "url": child.value})
-
-        return links
-
-    def extract_from_quick_access_tile_block(self, value):
-        links = []
-        if value["link"]:
-            for child in value["link"]:
-                if hasattr(child, "block_type") and child.block_type == "external_url":
-                    links.append({"text": value["title"], "url": child.value})
-
-        return links
-
-    def extract_from_card_tile_block(self, value):
-        links = []
-        if value["link"]:
-            for child in value["link"]:
-                if hasattr(child, "block_type") and child.block_type == "external_url":
-                    links.append({"text": value["card_header"], "url": child.value})
-
-        return links
-
-    def extract_from_table_list_block(self, value):
-        links = []
-        if value["table"]:
-            for row in value["table"].rows:
-                for cell in row:
-                    for child in cell.value:
-                        if hasattr(child.value, "source"):
-                            html = child.value.source
-                            soup = BeautifulSoup(html, "html.parser")
-                            for a in soup.find_all("a", href=True):
-                                href = a["href"]
-                                if (
-                                    not href.startswith("mailto:")
-                                    and not href.startswith("tel:")
-                                    and not href.startswith("#")
-                                ):
-                                    links.append(
-                                        {
-                                            "text": a.get_text(strip=True),
-                                            "url": href,
-                                        }
-                                    )
-
-        return links
-
-    def extract_from_typed_table_block(self, value):
-        links = []
-        for row in value.rows:
-            for cell in row:
-                html = cell.value.source
-                soup = BeautifulSoup(html, "html.parser")
-                for a in soup.find_all("a", href=True):
-                    href = a["href"]
-                    if (
-                        not href.startswith("mailto:")
-                        and not href.startswith("tel:")
-                        and not href.startswith("#")
-                    ):
-                        links.append(
-                            {
-                                "text": a.get_text(strip=True),
-                                "url": href,
-                            }
-                        )
-
-        return links
-
-    def extract_from_image_with_link_block(self, value):
-        links = []
-        if value["link"]:
-            for child in value["link"]:
-                if hasattr(child, "block_type") and child.block_type == "external_url":
-                    links.append({"text": value["image"].title, "url": child.value})
-
-        return links
+        return CustomLinkExtractor()

--- a/website/home/views.py
+++ b/website/home/views.py
@@ -14,6 +14,8 @@ from wagtail.admin.filters import (
 from wagtail.admin.ui.tables import Column
 from django.utils.html import format_html
 from django.utils import timezone
+from wagtail_external_links_report.views import ExternalLinksReportView
+from home.utils.custom_link_extractor import CustomLinkExtractor
 
 
 class NewsItemReportFilterSet(WagtailFilterSet):
@@ -485,3 +487,11 @@ class PDFChooserViewSet(DocumentChooserViewSet):
 
 
 PDF_CHOOSER_VIEWSET = PDFChooserViewSet("pdf_chooser")
+
+
+class CustomExternalLinksReportView(ExternalLinksReportView):
+    results_template_name = "home/custom_external_links_report_results.html"
+    page_title = "External Links"
+
+    def get_extractor(self):
+        return CustomLinkExtractor()

--- a/website/requirements/base.txt
+++ b/website/requirements/base.txt
@@ -58,3 +58,4 @@ wagtail-transfer @ git+https://github.com/ustaxcourt/wagtail-transfer@240daba
 whitenoise==6.8.2
 Willow
 social-auth-app-django==5.6.0
+wagtail-external-links-report==0.1.0

--- a/website/scripts/cypress/run_against_aws.sh
+++ b/website/scripts/cypress/run_against_aws.sh
@@ -257,6 +257,7 @@ fi
 
 set +e
 CYPRESS_INCLUDE_ADMIN_VALIDATION="$include_admin" \
+CYPRESS_INCLUDE_LOCAL_VALIDATION="false" \
 CYPRESS_ADMIN_USERNAME="$admin_username" \
 CYPRESS_ADMIN_PASSWORD="$admin_password" \
   "${cypress_cmd[@]}"


### PR DESCRIPTION
## Monday Ticket

**Ticket:** WAG-98

---

## Summary of Changes
Created an External Links report that allows admins, moderators, and editors to view external links on all pages of a Wagtail site. A Cypress test and management command have been created to test that all components that can have external links can be displayed within the report and that internal links are not displayed within the report.

---

## Testing Instructions
Provide clear steps for the reviewer to test this change. Please consider any manual steps.

- Login to Wagtail Admin
- Click the "Reports" button in the menu on the left side of the screen
- Click the "External Links" button in the submenu that appears
- Validate the report's content