### PR TITLE
docs: transition task management from Monday.com to Jira

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
-## Monday Ticket
-Please include the Monday ticket ID in the correct format.
+## Jira Ticket
+Please include the Jira issue ID in the correct format.
 
 **Format:** `WAG-XXX` (the dash is important)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,15 +45,15 @@ See: https://github.com/octoenergy/public-conventions/blob/main/conventions/terr
 
 ## Git Naming Conventions
 
-We are using Monday.com as an issue tracking system for project management. In order to get better metrics for performance and connect the code with the issues, we are requiring the following naming conventions for branches and pull requests:
+We are using Jira (https://ustaxcourt-team.atlassian.net/browse/WAG) as an issue tracking system for project management. In order to get better metrics for performance and connect the code with the issues, we are requiring the following naming conventions for branches and pull requests:
 
 ### Branch Names
 
-Please use a branch name that includes the Task ID in the name. **It must be uppercase** for it to properly link to the issue. For example, if the Task ID is "WAG-123" then the branch name should begin with "WAG-123-..." After that please use a brief summary of the work that the branch will do.
+Please use a branch name that includes the Issue ID in the name. **It must be uppercase** for it to properly link to the issue. For example, if the Issue ID is "WAG-123" then the branch name should begin with "WAG-123-..." After that please use a brief summary of the work that the branch will do.
 
 ### Pull Request Titles
 
-Please reference the Task ID in the Title or Description of any pull request. This way the Github integration will automatically connect a task in Monday.com with the Pull Request. Again, **it must be uppercase**. This will give us better insights and help drive decision making. For example, when you create a PR, please give it the title "Introduce Git Naming Conventions - WAG-375" or mention it in the description.
+Please reference the Issue ID in the Title or Description of any pull request. This way the Github integration will automatically connect a task in Jira with the Pull Request. Again, **it must be uppercase**. This will give us better insights and help drive decision making. For example, when you create a PR, please give it the title "Introduce Git Naming Conventions - WAG-375" or mention it in the description.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -512,13 +512,13 @@ Additionally, we will use tags to facilitate deployment to sandbox instances.
 
 ## The Workflow
 1. Pick up a story on the main board,
-2. Create feature branch that includes the Monday.com story ID e.g. `[type]/[brief-description]-[monday-id]`
+2. Create feature branch that includes the Jira story ID e.g. `[type]/[brief-description]-[jira-id]`
     - `type`: the type of change.
       - `page`: code that adds a new wagtail page to the repo, e.g. `page/about-us-1234`
       - `fix`: code that fixes a bug or adds/clarifies documentation, e.g. `fix/broken-dropdown-1234`
       - `feature`: code that adds or enhances functionality of the app, e.g. `feature/new-disco-theme-1234`
     - `brief-description`: a few words to describe the purpose of the branch
-    - `monday-id`: the value of the **Item ID** in Monday.com
+    - `jira-id`: the value of the **Issue ID** in Jira (e.g., WAG-123)
 3. Develop and test locally
 4. When ready for review, push branch to github (if not done already) and create a draft PR to `main`
 5. Deploy your feature to your sandbox by tagging your feature branch with `sandbox` , e.g.
@@ -533,7 +533,7 @@ Or, the following equivalent command.
 > Additionally, you can add/reassign tags using the Github website.
 
 6. Developer notifies team that feature is ready for review:
-  - by moving the story card in Monday.com to the `Waiting for review` lane, and
+  - by moving the story card in Jira to the `Waiting for review` lane, and
   - by notifying the stakeholders (UX, PO) in Teams that the feature is ready for testing.
 7. UX verifies AC in sandbox
 8. PO verifies AC in sandbox

--- a/README.md
+++ b/README.md
@@ -512,13 +512,13 @@ Additionally, we will use tags to facilitate deployment to sandbox instances.
 
 ## The Workflow
 1. Pick up a story on the main board,
-2. Create feature branch that includes the Jira story ID e.g. `[type]/[brief-description]-[jira-id]`
+2. Create feature branch that includes the Jira issue key e.g. `[type]/[brief-description]-[jira-key]`
     - `type`: the type of change.
       - `page`: code that adds a new wagtail page to the repo, e.g. `page/about-us-1234`
       - `fix`: code that fixes a bug or adds/clarifies documentation, e.g. `fix/broken-dropdown-1234`
       - `feature`: code that adds or enhances functionality of the app, e.g. `feature/new-disco-theme-1234`
     - `brief-description`: a few words to describe the purpose of the branch
-    - `jira-id`: the value of the **Issue ID** in Jira (e.g., WAG-123)
+    - `jira-key`: the value of the **Issue key** in Jira (e.g., WAG-123)
 3. Develop and test locally
 4. When ready for review, push branch to github (if not done already) and create a draft PR to `main`
 5. Deploy your feature to your sandbox by tagging your feature branch with `sandbox` , e.g.


### PR DESCRIPTION
This PR updates all project documentation (README, CONTRIBUTING, and PR template) to reflect the switch from Monday.com to Jira for task management. All references to 'Monday' have been replaced with 'Jira', and the project URL has been updated to https://ustaxcourt-team.atlassian.net/browse/WAG.