### PR TITLE
Fix bugs in CustomLinkExtractor and CustomExternalLinksReportView

### DIFF
--- a/website/home/utils/custom_link_extractor.py
+++ b/website/home/utils/custom_link_extractor.py
@@ -10,12 +10,15 @@ from wagtail.blocks import StructValue
 
 
 class CustomLinkExtractor(LinkExtractor):
-    def _get_external_link_with_text_from_attribute(value, text_attribute):
+    @staticmethod
+    def _get_external_link_with_text_from_attribute(
+        value, text_attribute, link_attribute="url"
+    ):
         links = []
-        if value["url"]:
-            for child in value["url"]:
+        if value[link_attribute]:
+            for child in value[link_attribute]:
                 if hasattr(child, "block_type") and child.block_type == "external_url":
-                    links.extend({"text": value[text_attribute], "url": child.value})
+                    links.append({"text": value[text_attribute], "url": child.value})
 
         return links
 
@@ -23,22 +26,36 @@ class CustomLinkExtractor(LinkExtractor):
         """Recursively extract links depending on value type."""
         links = []
 
-        if isinstance(value, StructValue) and isinstance(value, ButtonBlock):
-            links.extend(self._get_external_link_with_text_from_attribute("text"))
-            return links
-
-        if isinstance(value, StructValue) and isinstance(value, QuickAccessTileBlock):
-            links.extend(self._get_external_link_with_text_from_attribute("title"))
-            return links
-
-        if isinstance(value, StructValue) and isinstance(value, CardTileBlock):
+        if isinstance(value, StructValue) and isinstance(value.block, ButtonBlock):
             links.extend(
-                self._get_external_link_with_text_from_attribute("card_header")
+                self._get_external_link_with_text_from_attribute(value, "text")
             )
             return links
 
-        if isinstance(value, StructValue) and isinstance(value, ImageWithLinkBlock):
-            links.extend(self._get_external_link_with_text_from_attribute("image"))
+        if isinstance(value, StructValue) and isinstance(
+            value.block, QuickAccessTileBlock
+        ):
+            links.extend(
+                self._get_external_link_with_text_from_attribute(value, "title", "link")
+            )
+            return links
+
+        if isinstance(value, StructValue) and isinstance(value.block, CardTileBlock):
+            links.extend(
+                self._get_external_link_with_text_from_attribute(
+                    value, "card_header", "link"
+                )
+            )
+            return links
+
+        if isinstance(value, StructValue) and isinstance(
+            value.block, ImageWithLinkBlock
+        ):
+            image = value.get("image")
+            image_text = image.contextual_alt_text if image else ""
+            for child in value.get("link") or []:
+                if hasattr(child, "block_type") and child.block_type == "external_url":
+                    links.append({"text": image_text, "url": child.value})
             return links
 
         # Handles external links in Enhanced Tables, Styled Tables, and Unstyled Tables

--- a/website/home/views.py
+++ b/website/home/views.py
@@ -16,7 +16,6 @@ from django.utils.html import format_html
 from django.utils import timezone
 from wagtail_external_links_report.views import ExternalLinksReportView
 from home.utils.custom_link_extractor import CustomLinkExtractor
-from wagtail.admin.views.generic.base import BaseListingView
 
 
 class NewsItemReportFilterSet(WagtailFilterSet):
@@ -505,14 +504,10 @@ class CustomExternalLinksReportView(ExternalLinksReportView):
         return CustomLinkExtractor()
 
     def get_context_data(self, **kwargs):
-        context = BaseListingView.get_context_data(self, **kwargs)
-        extractor = self.get_extractor()
-
-        for page in context["object_list"]:
-            page.external_links = extractor.extract_from_page(page)
+        context = super().get_context_data(**kwargs)
 
         if self.is_export:
-            context["object_list"] = self.export_rows(context["object_list"])
+            context["object_list"] = self.export_rows(context["page_obj"])
 
         return context
 


### PR DESCRIPTION
## Summary

This PR fixes three categories of bugs found during code review of #695, all of which caused the External Links Report to either silently produce incorrect results or return a 500 error.

---

### Bug 1: `isinstance` checks against block classes instead of `value.block`

**Files:** `home/utils/custom_link_extractor.py`

The four custom block handlers (Button, QuickAccessTile, CardTile, ImageWithLink) used:
```python
isinstance(value, ButtonBlock)  # always False
```
`value` is a `StructValue` (a dict-like object); `ButtonBlock` is a block class. These checks always evaluated to `False`, making all four handlers dead code. The base class's generic recursion handled these blocks instead, silently missing links in some cases.

**Fix:** Check `value.block` (the StructValue carries a reference to its originating block):
```python
isinstance(value.block, ButtonBlock)  # correct
```

---

### Bug 2: `_get_external_link_with_text_from_attribute` — wrong signature, wrong field name, `extend` vs `append`

**Files:** `home/utils/custom_link_extractor.py`

Three separate problems in this helper method:

1. **No `self` / missing `@staticmethod`**: The method was declared without `self` but not decorated as `@staticmethod`. Python treated it as an instance method, so when called as `self._get_external_link_with_text_from_attribute("text")`, `value` received `self` and `text_attribute` received `"text"` — the actual StructValue was never passed. This would have caused an immediate crash if the isinstance checks (Bug 1) had actually worked.

2. **Hardcoded `value["url"]`**: `QuickAccessTileBlock`, `CardTileBlock`, and `ImageWithLinkBlock` all store their link in a field named `link`, not `url`. Only `ButtonBlock` uses `url`. Once Bug 1 was fixed, the `QuickAccessTile`/`CardTile`/`ImageWithLink` handlers crashed with a `KeyError` (causing the 500).

3. **`links.extend(dict)`**: `extend` on a dict iterates over its keys, so this was appending `["text", "url"]` to the list instead of the intended `{"text": ..., "url": ...}` dict. Should be `links.append(...)`.

**Fix:** Added `@staticmethod`, added a `link_attribute="url"` parameter (callers that use `link` pass it explicitly), fixed all call sites to pass `value` as the first argument, and changed `extend` → `append`.

---

### Bug 3: `ImageWithLinkBlock` — `Image` model has no `.get()`

**Files:** `home/utils/custom_link_extractor.py`

Wagtail's `ImageBlock.to_python()` returns the raw `Image` model instance (not a StructValue) for backward compatibility with `ImageChooserBlock`. The original code attempted `value["image"].get("alt_text", "")`, which fails with `AttributeError: 'Image' object has no attribute 'get'`. The alt text is instead available as `image.contextual_alt_text` (set by `ImageBlock` on the model instance).

**Fix:** Rewrote the `ImageWithLinkBlock` handler to use `image.contextual_alt_text` directly.

---

### Bug 4: `get_context_data` bypassed the MRO, breaking normal page views (the 500)

**Files:** `home/views.py`

`CustomExternalLinksReportView.get_context_data` called `BaseListingView.get_context_data(self, **kwargs)` directly instead of `super()`. This skipped `ExternalLinksReportView.get_context_data` (which sets `external_links` on each page) and also skipped `ExportableMixin.setup()` in the MRO, which is responsible for setting `self.is_export`. Without `self.is_export`, the view raised `AttributeError` on every normal page load — producing the 500.

The parent class `ExternalLinksReportView.get_context_data` already handles setting `external_links` on all pages via `super().get_context_data()`. The custom override only needs to add export-flattening on top.

**Fix:** Replace the direct `BaseListingView` call with `super().get_context_data(**kwargs)` and remove the now-redundant extractor loop. The export path reads from `context["page_obj"]` (the correct paginated result set) rather than `context["object_list"]`.