### PR TITLE
fix: WAG-1226 coverage workflow env var bug and omit patterns

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -43,9 +43,8 @@ jobs:
       run: |
         cd website
         . ../.venv/bin/activate
-        coverage run -m pytest
-        coverage report -m | tee coverage-report.txt
-        coverage xml -o coverage.xml
+        set -o pipefail
+        pytest --cov --cov-report=term-missing --cov-report=xml:coverage.xml | tee coverage-report.txt
 
     - name: Parse coverage metrics
       id: coverage_metrics

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -56,12 +56,12 @@ jobs:
 
     - name: Add Coverage to Step Summary
       if: always() && hashFiles('website/coverage-report.txt') != ''
+      env:
+        COVERAGE_PERCENT: ${{ steps.coverage_metrics.outputs.coverage_percent }}
       run: |
-        COVERAGE_PERCENT='${{ steps.coverage_metrics.outputs.coverage_percent }}'
-        COVERAGE_MINIMUM='${{ env.COVERAGE_MINIMUM }}'
-        STATUS="PASS"
-        if python -c "import os,sys; c=float(os.environ['COVERAGE_PERCENT']); m=float(os.environ['COVERAGE_MINIMUM']); sys.exit(0 if c < m else 1)"
-        then
+        if python -c "import os,sys; sys.exit(0 if float(os.environ['COVERAGE_PERCENT']) >= float(os.environ['COVERAGE_MINIMUM']) else 1)"; then
+          STATUS="PASS"
+        else
           STATUS="FAIL"
         fi
 

--- a/website/.coveragerc
+++ b/website/.coveragerc
@@ -2,8 +2,8 @@
 source = .
 branch = True
 omit =
-    tests/*
-    *test.py
+    */tests/*
+    */test_*.py
     */migrations/*
     manage.py
     app/settings/*
@@ -11,8 +11,8 @@ omit =
 
 [report]
 omit =
-    tests/*  # Exclude any directory named 'tests'
-    *test.py   # Exclude any file ending in 'test.py'
+    */tests/*
+    */test_*.py
     */migrations/*
     manage.py
     app/settings/*

--- a/website/requirements/local.txt
+++ b/website/requirements/local.txt
@@ -1,6 +1,7 @@
 -r base.txt
 
 coverage==7.6.10
+pytest-cov==7.1.0
 djlint==1.36.4
 django-debug-toolbar
 mypy==1.14.1

--- a/website/requirements/local.txt
+++ b/website/requirements/local.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-coverage==7.6.10
+coverage==7.14.1
 pytest-cov==7.1.0
 djlint==1.36.4
 django-debug-toolbar


### PR DESCRIPTION
## Monday Ticket

**Ticket:** https://ustaxcourt-team.atlassian.net/browse/WAG-1226

---

## Summary of Changes

Fixes three bugs identified during review of PR #697, all confirmed via CI runs on throwaway PRs #706 and #707.

**Bug 1 — \`COVERAGE_PERCENT\` not in env (summary always showed PASS)**

The \`Add Coverage to Step Summary\` step set \`COVERAGE_PERCENT\` as a shell
variable (no \`export\`), so \`os.environ['COVERAGE_PERCENT']\` raised \`KeyError\`
in the Python subprocess. This caused Python to exit 1, the \`if\` block was
skipped, and \`STATUS\` was hardcoded to \`"PASS"\` regardless of actual coverage.

Fix: add an \`env:\` block to the step (matching the pattern already used
correctly in the \`Enforce minimum coverage\` step). Also simplified the logic
to use conventional exit codes (0=pass, 1=fail) for readability.

Confirmed in CI: PR #706 log showed \`KeyError: 'COVERAGE_PERCENT'\`; PR #707 log showed \`COVERAGE_PERCENT: 74\` correctly in env and STATUS displayed as FAIL.

**Bug 2 — \`.coveragerc\` omit patterns didn't match actual test file naming**

\`*test.py\` matches files ending in \`test.py\`, but this repo uses the
\`test_*.py\` prefix convention. Updated to \`*/test_*.py\`. Also cleaned up
inline comments in the \`[report]\` section.

**Bug 3 — \`MishaKav/pytest-coverage-comment\` format mismatch (no PR comment posted)**

\`coverage report -m\` output was rejected by the action with "bad format or wrong data" — no coverage comment was being posted on any PR, meaning AC #4 was not actually met.

Fix: switch to \`pytest --cov --cov-report=term-missing\` (via \`pytest-cov\`), which generates the \`---------- coverage: platform\` header the action expects. Also adds \`set -o pipefail\` so test failures still fail the step when piped to \`tee\`, and removes the now-redundant separate \`coverage xml\` command.

Required bumping \`coverage\` from \`7.6.10\` to \`7.14.1\` to satisfy \`pytest-cov==7.1.0\`'s dependency on \`coverage>=7.10.6\`.

Confirmed in CI: PR #706 logged "Nothing to report"; PR #707 logged "coverage: 74%, creating a new one" and posted a comment successfully.

---

## Testing Instructions

- PR #706 (break-it off original PR #697 branch): pipeline fails on enforcement gate ✅, but step summary shows STATUS=PASS (Bug 1) and no PR comment posted (Bug 3)
- PR #707 (break-it off this fix branch): pipeline fails on enforcement gate ✅, step summary correctly shows STATUS=FAIL, and PR comment is posted with 74% in yellow

---

## Reviewer Notes

This PR is intended to be merged into PR #697's branch before that PR merges to main. The fixes are isolated to \`.github/workflows/pull-requests.yml\`, \`website/.coveragerc\`, and \`website/requirements/local.txt\`.