### PR TITLE
fix: guard against None in pageurl calls for internal_page links [WAG-1285]

### DIFF
--- a/website/app/templates/includes/card_tiles.html
+++ b/website/app/templates/includes/card_tiles.html
@@ -274,7 +274,7 @@
            tabindex="0"
            aria-label="{{ tile.card_header }}"
            data-link-type="{{ link.block_type }}"
-           {% if link.block_type == 'internal_page' %}
+           {% if link.block_type == 'internal_page' and link.value %}
                data-href="{% pageurl link.value %}"
            {% elif link.block_type == 'external_url' %}
                data-href="{{ link.value }}" data-is-external="true"

--- a/website/app/templates/includes/enhanced_body.html
+++ b/website/app/templates/includes/enhanced_body.html
@@ -34,7 +34,7 @@
                 <div class="centered-image">
                     {% with link_item=block.value.link.0 %}
                     {% if link_item %}
-                        <a href="{% if link_item.block_type == 'external_url' %}{{ link_item.value }}{% elif link_item.block_type == 'internal_page' %}{% pageurl link_item.value %}{% elif link_item.block_type == 'internal_pdf' %}{{ link_item.value.url }}{% endif %}">
+                        <a href="{% if link_item.block_type == 'external_url' %}{{ link_item.value }}{% elif link_item.block_type == 'internal_page' and link_item.value %}{% pageurl link_item.value %}{% elif link_item.block_type == 'internal_pdf' %}{{ link_item.value.url }}{% endif %}">
                     {% endif %}
                     {% picture block.value.image format-jpeg width-1000 loading="lazy" %}
                     {% if link_item %}

--- a/website/app/templates/includes/styled_button.html
+++ b/website/app/templates/includes/styled_button.html
@@ -34,7 +34,7 @@
    data-is-link="true"
    {% if link_item.block_type == 'external_url' %}
       href="{{ link_item.value }}"
-   {% elif link_item.block_type == 'internal_page' %}
+   {% elif link_item.block_type == 'internal_page' and link_item.value %}
       href="{% pageurl link_item.value %}"
    {% elif link_item.block_type == 'internal_pdf' %}
       href="{{ link_item.value.url }}"

--- a/website/app/templates/photo_plus_text.html
+++ b/website/app/templates/photo_plus_text.html
@@ -8,7 +8,7 @@
         <div class="dedication-image {% if photo_rendition.width > photo_rendition.height %}dedication-image--landscape{% endif %}">
             {% with link_item=block.value.link.0 %}
             {% if link_item %}
-                <a href="{% if link_item.block_type == 'external_url' %}{{ link_item.value }}{% elif link_item.block_type == 'internal_page' %}{% pageurl link_item.value %}{% elif link_item.block_type == 'internal_pdf' %}{{ link_item.value.url }}{% endif %}">
+                <a href="{% if link_item.block_type == 'external_url' %}{{ link_item.value }}{% elif link_item.block_type == 'internal_page' and link_item.value %}{% pageurl link_item.value %}{% elif link_item.block_type == 'internal_pdf' %}{{ link_item.value.url }}{% endif %}">
             {% endif %}
             <img src="{{ photo_rendition.url }}" width="{{ photo_rendition.width }}" height="{{ photo_rendition.height }}" alt="{{ block.value.alt_text }}" {% if not link_item %}tabindex="0"{% endif %} role="img">
             {% if link_item %}


### PR DESCRIPTION
## Jira Ticket

**Ticket:** `WAG-1285`

---

## Summary of Changes

`PageChooserBlock` can resolve to `None` when a linked page doesn't exist in the local database — for example, after a `wagtail-transfer` import where the source page references a page that wasn't transferred, or if a page is deleted while still referenced by a button/image/card block.

When `link_item.value` is `None`, the `{% pageurl %}` template tag raises a hard `ValueError: pageurl tag expected a Page object, got None`, crashing the page render entirely.

This fix adds `and link_item.value` / `and link.value` guards before each `{% pageurl %}` call across all four affected templates. When the linked page is missing, the element renders with an empty `href` rather than crashing.

**Files changed:**
- `app/templates/includes/styled_button.html`
- `app/templates/includes/enhanced_body.html`
- `app/templates/includes/card_tiles.html`
- `app/templates/photo_plus_text.html`

---

## Testing Instructions

- [ ] In Wagtail admin, use the **Import** feature (Pages → Import from dev-web) to import the page **"Dev-Web QA Enhanced Table Component Test Page"** from `dev-web.ustaxcourt.gov`
- [ ] Navigate to the imported page at its local URL — confirm it renders without a `ValueError` crash
- [ ] Verify buttons/cards with `internal_page` links pointing to pages that exist locally still render their `href` correctly
- [ ] Link to sandbox (if deployed):
- [ ] Any special accounts, flags, or permissions needed: Wagtail admin access; `WAGTAILTRANSFER_SOURCES` configured for dev-web

---

## Post-Deployment Steps (if any)

None.

---

## Remaining Work (if any)

None.

---

## Reviewer Notes

This was discovered during a `wagtail-transfer` import from dev-web. The root cause is that `wagtailcore.page` is intentionally excluded from `WAGTAILTRANSFER_NO_FOLLOW_MODELS` to avoid pulling in the entire page tree, so internal page references imported this way will always resolve to `None` unless the target page happens to exist locally. The template should be resilient to this rather than crashing.