### PR TITLE
TEST: WAG-1232 e2e coverage workflow trigger (throwaway)

### DIFF
--- a/.github/workflows/e2e-coverage.yml
+++ b/.github/workflows/e2e-coverage.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   e2e-coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/e2e-coverage.yml
+++ b/.github/workflows/e2e-coverage.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   e2e-coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 360
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Throwaway PR — do not merge

This PR exists solely to trigger the `e2e-coverage.yml` GitHub Actions workflow added in PR #711 ([WAG-1232](https://ustaxcourt-team.atlassian.net/browse/WAG-1232)) so the workflow can be observed and validated before merging.

**Base branch:** `feature-wag1232-Github-Action-for-E2E-Test-Coverage` (PR #711)

Delete this PR and branch once testing is complete.

[WAG-1232]: https://ustaxcourt-team.atlassian.net/browse/WAG-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ