### PR TITLE
test: throwaway PR to verify e2e coverage workflow (WAG-1232)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Byte-compiled / optimized / DLL files
+
 __pycache__/
 *.py[cod]
 *$py.class


### PR DESCRIPTION
Throwaway PR to verify the Cypress E2E Coverage workflow behavior described in #711.

Only change is a blank line in `.gitignore`. Safe to close/delete after verification.