### PR TITLE
fix: reliably write e2e coverage data on server shutdown (WAG-1232)

### DIFF
--- a/.github/workflows/e2e-coverage.yml
+++ b/.github/workflows/e2e-coverage.yml
@@ -51,12 +51,12 @@ jobs:
           make createpages
           make updatepages
 
-          COVERAGE_FILE=.coverage.e2e coverage run --rcfile=.coveragerc.e2e --parallel-mode manage.py runserver --noreload 0.0.0.0:8000 > /tmp/e2e-server.log 2>&1 &
+          COVERAGE_FILE=.coverage.e2e python scripts/run_covered_server.py > /tmp/e2e-server.log 2>&1 &
           SERVER_PID=$!
 
           cleanup() {
             if kill -0 "$SERVER_PID" 2>/dev/null; then
-              kill -INT "$SERVER_PID" 2>/dev/null || true
+              kill -TERM "$SERVER_PID" 2>/dev/null || true
               # Wait up to 30s for coverage data to be written, then force-kill
               (sleep 30; kill -KILL "$SERVER_PID" 2>/dev/null || true) &
               KILL_TIMER_PID=$!

--- a/website/scripts/run_covered_server.py
+++ b/website/scripts/run_covered_server.py
@@ -17,6 +17,11 @@ import runpy
 import signal
 import sys
 
+# runpy.run_path on a .py file does not update sys.path the way `python
+# manage.py` does. Add website/ (parent of this scripts/ dir) explicitly so
+# that `app`, `home`, and other project packages are importable.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import coverage
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.local")

--- a/website/scripts/run_covered_server.py
+++ b/website/scripts/run_covered_server.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+Run Django's dev server under coverage instrumentation with reliable shutdown.
+
+Standard `coverage run manage.py runserver` relies on Python's atexit to flush
+coverage data, but atexit doesn't run after SIGKILL. Django's threaded dev
+server often ignores SIGINT long enough that the workflow's 30-second kill
+timer fires, resulting in SIGKILL and no coverage file.
+
+This script installs explicit SIGINT and SIGTERM handlers that call
+coverage.stop() / coverage.save() and then os._exit(), bypassing both the
+atexit problem and any non-daemon threads that would otherwise block sys.exit().
+"""
+
+import os
+import runpy
+import signal
+import sys
+
+import coverage
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.local")
+
+cov = coverage.Coverage(
+    config_file=".coveragerc.e2e",
+    data_file=os.environ.get("COVERAGE_FILE", ".coverage.e2e"),
+    data_suffix=True,
+)
+cov.start()
+
+
+def _shutdown(signum, frame):
+    cov.stop()
+    cov.save()
+    os._exit(0)
+
+
+signal.signal(signal.SIGTERM, _shutdown)
+signal.signal(signal.SIGINT, _shutdown)
+
+sys.argv = ["manage.py", "runserver", "--noreload", "0.0.0.0:8000"]
+runpy.run_path("manage.py", run_name="__main__")
+
+cov.stop()
+cov.save()


### PR DESCRIPTION
## Jira Ticket

**Ticket:** [WAG-1232](https://ustaxcourt-team.atlassian.net/browse/WAG-1232)

## Problem

The `Generate E2E coverage report` step was being skipped because no `.coverage.e2e*` file was written after Cypress finished. Root cause traced via run logs from the throwaway PR (#719):

- All Cypress tests passed at `16:22:13`
- The next step didn't start until `16:22:43` — exactly **30 seconds later**
- That gap is the SIGKILL timer in the cleanup trap firing

The cleanup sent `kill -INT $SERVER_PID`, but Django's threaded dev server didn't exit within 30 seconds (non-daemon request-handler threads block `sys.exit()` after `KeyboardInterrupt`). The 30-second fallback SIGKILL fired, which terminates the process without running Python's `atexit` — so `coverage` never wrote its data file. `hashFiles('website/.coverage.e2e*')` returned empty and all three downstream steps were skipped.

## Fix

Replaces `coverage run manage.py runserver` with `scripts/run_covered_server.py`, a small wrapper that:

1. Starts `coverage.Coverage` via the Python API (same config/data_file as before)
2. Installs explicit `SIGTERM` and `SIGINT` handlers that call `cov.stop()` → `cov.save()` → `os._exit(0)` — writing the coverage file unconditionally and exiting immediately without waiting on threads
3. Runs Django via `runpy.run_path('manage.py')` in the same process

The workflow cleanup is also updated from `kill -INT` to `kill -TERM`, which is the conventional "please shut down" signal and matches the handler installed by the script.

## What doesn't change

- Coverage config, source scoping, and data file naming are identical
- The `coverage combine` / `coverage report` steps downstream are untouched
- All Cypress tests still run exactly as before

[WAG-1232]: https://ustaxcourt-team.atlassian.net/browse/WAG-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ