### PR TITLE
Added cache behavior block to cloudfront.tf to disable caching of /wagtail-transfer* calls

### DIFF
--- a/infra/modules/app/cloudfront.tf
+++ b/infra/modules/app/cloudfront.tf
@@ -257,6 +257,19 @@ resource "aws_cloudfront_distribution" "app" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  # Cache behavior for /wagtail-transfer path - no caching
+  ordered_cache_behavior {
+    path_pattern     = "/wagtail-transfer*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "app-origin"
+
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+    origin_request_policy_id = aws_cloudfront_origin_request_policy.dynamic_content.id
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"


### PR DESCRIPTION
## Jira Ticket

**Ticket:** WAG-1302

---

## Summary of Changes
Updated the CloudFront Terraform script to include a cache behavior section that disables caching for any Wagtail Transfer API calls. This resolves an issue where a page/snippet that is transferred, immediately updated in the source environment, and transferred again to the destination environment all within 5 minutes of the initial transfer was preventing the update from appearing in the destination environment.

---

## Testing Instructions

1. Create a new page/snippet or update an existing page/snippet in a source environment.
2. In a destination environment, use Wagtail Transfer to transfer the new/updated page/snippet from the source environment.
3. In the source environment, update the page/snippet from step 1 to have a change.
4. Within 5 minutes of step 2 being completed, use Wagtail Transfer in the destination environment to transfer the same page/snippet from the source environment used in step 2.