### PR TITLE
WAG-1247: PSD breadcrumb matches prod Guidance for Practitioners pattern

### DIFF
--- a/website/home/templates/home/private_seminar_disclosures.html
+++ b/website/home/templates/home/private_seminar_disclosures.html
@@ -18,6 +18,18 @@
             margin-bottom: 15px;
         }
 
+        /* Breadcrumb-style page title — matches the prod Guidance for
+           Practitioners pattern (page-title-start as an underlined link,
+           page-title-breadcrumb as plain text after a separator). */
+        #private-seminar-page .page-title .page-title-start {
+            text-decoration: underline;
+            cursor: pointer;
+        }
+        #private-seminar-page .page-title .page-title-breadcrumb {
+            color: #1b1b1b;
+            text-decoration: none;
+        }
+
         /* ── Intro text block (policy paragraph + "Below is…" label) ───── */
         .seminar-intro {
             font-size: 1.0625rem;   /* 17px */
@@ -260,14 +272,16 @@
 {% block content %}
     <div id="private-seminar-page" class="grid-container">
         {% comment %}
-           H1: page title with an inline back-link to Judge Information, so
-           keyboard / AT users get an in-heading way back to the parent
-           page (and to satisfy the [data-testid="page-title"] a Cypress +
-           VoiceOver expectations).
+           H1 breadcrumb pattern matches the prod Guidance for Practitioners
+           page: a page-title-start <a> linking back to the parent page,
+           followed by a page-title-breadcrumb <span> for the current page
+           name. Using an actual <a> (not a JS-handled span) so browser
+           back/forward, right-click menus, and the existing Cypress +
+           VoiceOver expectations on [data-testid="page-title"] a all keep
+           working.
         {% endcomment %}
         <h1 class="page-title" data-testid="page-title" tabindex="0">
-            <a href="/judges/" class="page-title-back-link">Judge Information</a>
-            <span class="page-title-sep" aria-hidden="true"> / </span>Private Seminar Disclosures
+            <a href="/judges/" class="page-title-start" id="page-title-start">Judge Information</a><span class="page-title-breadcrumb" id="page-title-breadcrumb"> / Private Seminar Disclosures</span>
         </h1>
         {# Intro: policy paragraph from CMS richtext field #}
         {% if disclosures and page.seminar_intro_text %}

--- a/website/home/templates/home/private_seminar_disclosures.html
+++ b/website/home/templates/home/private_seminar_disclosures.html
@@ -25,16 +25,11 @@
             color: inherit;
             font-weight: inherit;
             text-decoration: underline;
-            cursor: pointer;
         }
         #private-seminar-page .page-title .page-title-start:hover,
         #private-seminar-page .page-title .page-title-start:focus,
         #private-seminar-page .page-title .page-title-start:visited {
             color: inherit;
-        }
-        #private-seminar-page .page-title .page-title-breadcrumb {
-            color: inherit;
-            text-decoration: none;
         }
 
         /* ── Intro text block (policy paragraph + "Below is…" label) ───── */
@@ -278,7 +273,7 @@
 {% block body_class %}template-private-seminar-disclosures{% endblock %}
 {% block content %}
     <div id="private-seminar-page" class="grid-container">
-        {# H1 breadcrumb matches the prod Guidance for Practitioners pattern. Real <a> (not JS-handled span) so browser back/forward + the existing [data-testid="page-title"] a Cypress/VoiceOver assertions still work. #}
+        {# H1 breadcrumb matches the prod Guidance for Practitioners pattern. Real <a> (not JS-handled span) so browser back/forward + the existing `[data-testid="page-title"] a` Cypress/VoiceOver assertions still work. #}
         <h1 class="page-title" data-testid="page-title" tabindex="0">
             <a href="/judges/" class="page-title-start" id="page-title-start">Judge Information</a><span class="page-title-breadcrumb" id="page-title-breadcrumb"> / Private Seminar Disclosures</span>
         </h1>

--- a/website/home/templates/home/private_seminar_disclosures.html
+++ b/website/home/templates/home/private_seminar_disclosures.html
@@ -18,15 +18,22 @@
             margin-bottom: 15px;
         }
 
-        /* Breadcrumb-style page title — matches the prod Guidance for
-           Practitioners pattern (page-title-start as an underlined link,
-           page-title-breadcrumb as plain text after a separator). */
+        /* Pin color + font-weight to inherit so the global `a { color:
+           var(--color-link); font-weight: bold }` rule doesn't render
+           this link blue + bold. Matches prod's <span>-based pattern. */
         #private-seminar-page .page-title .page-title-start {
+            color: inherit;
+            font-weight: inherit;
             text-decoration: underline;
             cursor: pointer;
         }
+        #private-seminar-page .page-title .page-title-start:hover,
+        #private-seminar-page .page-title .page-title-start:focus,
+        #private-seminar-page .page-title .page-title-start:visited {
+            color: inherit;
+        }
         #private-seminar-page .page-title .page-title-breadcrumb {
-            color: #1b1b1b;
+            color: inherit;
             text-decoration: none;
         }
 
@@ -271,15 +278,7 @@
 {% block body_class %}template-private-seminar-disclosures{% endblock %}
 {% block content %}
     <div id="private-seminar-page" class="grid-container">
-        {% comment %}
-           H1 breadcrumb pattern matches the prod Guidance for Practitioners
-           page: a page-title-start <a> linking back to the parent page,
-           followed by a page-title-breadcrumb <span> for the current page
-           name. Using an actual <a> (not a JS-handled span) so browser
-           back/forward, right-click menus, and the existing Cypress +
-           VoiceOver expectations on [data-testid="page-title"] a all keep
-           working.
-        {% endcomment %}
+        {# H1 breadcrumb matches the prod Guidance for Practitioners pattern. Real <a> (not JS-handled span) so browser back/forward + the existing [data-testid="page-title"] a Cypress/VoiceOver assertions still work. #}
         <h1 class="page-title" data-testid="page-title" tabindex="0">
             <a href="/judges/" class="page-title-start" id="page-title-start">Judge Information</a><span class="page-title-breadcrumb" id="page-title-breadcrumb"> / Private Seminar Disclosures</span>
         </h1>


### PR DESCRIPTION
## Summary
Switch the Private Seminar Disclosures page H1 from its bespoke `page-title-back-link` / `page-title-sep` markup to the same `page-title-start` + `page-title-breadcrumb` pattern used on the prod **Guidance for Practitioners** page (and on the **Judges** page when a filter is applied). Per Jenna — we want the breadcrumb styling consistent across the whole site.

## What changed
- `private_seminar_disclosures.html` — one template file:
  - H1 now renders as `<a class="page-title-start" href="/judges/">Judge Information</a><span class="page-title-breadcrumb"> / Private Seminar Disclosures</span>`.
  - Added page-scoped CSS that pins `color: inherit` and `font-weight: inherit` on `.page-title-start` so the global `a { color: var(--color-link); font-weight: bold }` rule in `app.css` doesn't render the link blue + bold.

## Why we used an `<a>` instead of prod's JS-handled `<span>`
The Enhanced Standard Page uses a `<span role="button">` because clicking it just toggles a `?card=` query param — no navigation. PSD really does navigate to a different page, so a real `<a href="/judges/">` is correct:
- Browser back/forward + right-click "open in new tab" work without extra JS.
- The existing `[data-testid="page-title"] a` Cypress + VoiceOver assertions keep working.
- Visual output matches prod because the `color: inherit` + `font-weight: inherit` overrides override the global anchor styling.

## Judges page
Already uses the prod pattern (`<span class="page-title-start">` + `<span class="page-title-breadcrumb">`); verified locally that the breadcrumb on `/judges/?filter=…` reads correctly (dark text, regular weight). No change needed.

## Test plan
- [x] Local `make resetdb && make run` → `/judges/private-seminar-disclosures/` breadcrumb visually matches the prod `/practitioners/?card=…` screenshot.
- [x] `cypress/e2e/pages/private_seminar_disclosures.cy.ts` → **46/46 passing** locally.
- [x] `cypress/e2e/pages/judge_information.cy.ts` → **125/125 passing** locally.
- [x] `pytest tests/home/models/test_judge_index.py` → **46/46 passing** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)