### PR TITLE
WAG-1270 - Unit tests for wagtaillinkchecker

### DIFF
--- a/website/tests/app/test_wagtaillinkchecker_models.py
+++ b/website/tests/app/test_wagtaillinkchecker_models.py
@@ -1,0 +1,361 @@
+"""Tests for app/wagtaillinkchecker/models.py and app/wagtaillinkchecker/tasks.py"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from wagtail.models import Locale, Page, Site
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_site():
+    """Return a minimal Wagtail Site backed by a real root Page."""
+    Locale.objects.get_or_create(language_code="en")
+    root_page = Page.objects.filter(depth=1).first()
+    if root_page is None:
+        root_page = Page.add_root(title="Root", slug="root")
+    site, _ = Site.objects.get_or_create(
+        hostname="testserver-linkchecker",
+        defaults={
+            "root_page": root_page,
+            "is_default_site": False,
+            "port": 80,
+            "site_name": "Test Site",
+        },
+    )
+    return site
+
+
+def _make_scan(site):
+    from app.wagtaillinkchecker.models import Scan
+
+    return Scan.objects.create(site=site)
+
+
+def _make_scan_link(
+    scan, url, *, broken=False, crawled=False, invalid=False, page=None
+):
+    from app.wagtaillinkchecker.models import ScanLink
+
+    return ScanLink.objects.create(
+        scan=scan,
+        url=url,
+        broken=broken,
+        crawled=crawled,
+        invalid=invalid,
+        page=page,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scan.is_finished
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestScanIsFinished:
+    def test_is_finished_returns_true_when_status_is_completed(self):
+        from app.wagtaillinkchecker.models import Scan
+
+        scan = _make_scan(_make_site())
+        scan.status = Scan.Status.COMPLETED
+        assert scan.is_finished is True
+
+    def test_is_finished_returns_false_when_status_is_running(self):
+        scan = _make_scan(_make_site())
+        assert scan.is_finished is False
+
+    def test_is_finished_returns_false_when_status_is_failed(self):
+        from app.wagtaillinkchecker.models import Scan
+
+        scan = _make_scan(_make_site())
+        scan.status = Scan.Status.FAILED
+        assert scan.is_finished is False
+
+
+# ---------------------------------------------------------------------------
+# ScanLinkQuerySet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestScanLinkQuerySet:
+    def _setup(self):
+        """Create a scan with a varied set of links covering all flag combinations."""
+        scan = _make_scan(_make_site())
+        working = _make_scan_link(scan, "https://example.com/working", crawled=True)
+        broken = _make_scan_link(
+            scan, "https://example.com/broken", broken=True, crawled=True
+        )
+        uncrawled = _make_scan_link(scan, "https://example.com/uncrawled")
+        invalid = _make_scan_link(
+            scan, "https://example.com/invalid", invalid=True, crawled=True
+        )
+        # A link that is both broken and invalid — should NOT appear in broken_links()
+        invalid_and_broken = _make_scan_link(
+            scan,
+            "https://example.com/invalid-broken",
+            invalid=True,
+            broken=True,
+            crawled=True,
+        )
+        return scan, working, broken, uncrawled, invalid, invalid_and_broken
+
+    def test_valid_excludes_links_marked_invalid(self):
+        scan, working, broken, uncrawled, invalid, invalid_and_broken = self._setup()
+        qs = scan.links.valid()
+        assert invalid not in qs
+        assert invalid_and_broken not in qs
+
+    def test_valid_includes_non_invalid_links(self):
+        scan, working, broken, uncrawled, *_ = self._setup()
+        qs = scan.links.valid()
+        assert working in qs
+        assert broken in qs
+        assert uncrawled in qs
+
+    def test_broken_links_returns_only_valid_broken_links(self):
+        scan, working, broken, uncrawled, invalid, invalid_and_broken = self._setup()
+        qs = scan.links.broken_links()
+        assert broken in qs
+        assert working not in qs
+
+    def test_broken_links_excludes_links_marked_as_invalid(self):
+        """broken_links() chains through valid(), so a link with invalid=True is excluded even if broken=True."""
+        scan, *_, invalid_and_broken = self._setup()
+        qs = scan.links.broken_links()
+        assert invalid_and_broken not in qs
+
+    def test_crawled_links_returns_valid_crawled_links(self):
+        scan, working, broken, uncrawled, invalid, _ = self._setup()
+        qs = scan.links.crawled_links()
+        assert working in qs
+        assert broken in qs
+        assert uncrawled not in qs
+        assert invalid not in qs
+
+    def test_invalid_links_returns_only_invalid_links(self):
+        scan, working, broken, uncrawled, invalid, invalid_and_broken = self._setup()
+        qs = scan.links.invalid_links()
+        assert invalid in qs
+        assert invalid_and_broken in qs
+        assert working not in qs
+        assert broken not in qs
+
+    def test_working_links_returns_valid_crawled_not_broken(self):
+        scan, working, broken, uncrawled, invalid, _ = self._setup()
+        qs = scan.links.working_links()
+        assert working in qs
+        assert broken not in qs
+        assert uncrawled not in qs
+        assert invalid not in qs
+
+    def test_non_scanned_links_returns_uncrawled_links(self):
+        scan, working, broken, uncrawled, *_ = self._setup()
+        qs = scan.links.non_scanned_links()
+        assert uncrawled in qs
+        assert working not in qs
+        assert broken not in qs
+
+
+# ---------------------------------------------------------------------------
+# ScanLink.page_is_deleted (no DB needed — pure property logic)
+# ---------------------------------------------------------------------------
+
+
+class TestScanLinkPageIsDeleted:
+    def test_page_is_deleted_when_both_page_deleted_and_slug_are_set(self):
+        # NOTE: page_is_deleted returns `self.page_deleted and self.page_slug`, so when
+        # truthy the return value is the slug string, not the boolean True. Tests use
+        # truthiness rather than identity to reflect actual behavior.
+        from app.wagtaillinkchecker.models import ScanLink
+
+        link = ScanLink()
+        link.page_deleted = True
+        link.page_slug = "some-slug"
+        assert link.page_is_deleted
+
+    def test_page_is_not_deleted_when_page_deleted_is_false(self):
+        from app.wagtaillinkchecker.models import ScanLink
+
+        link = ScanLink()
+        link.page_deleted = False
+        link.page_slug = "some-slug"
+        assert not link.page_is_deleted
+
+    def test_page_is_not_deleted_when_slug_is_none(self):
+        # NOTE: returns None (not False) when slug is absent — see comment above.
+        from app.wagtaillinkchecker.models import ScanLink
+
+        link = ScanLink()
+        link.page_deleted = True
+        link.page_slug = None
+        assert not link.page_is_deleted
+
+
+# ---------------------------------------------------------------------------
+# delete_tag signal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestDeleteTagSignal:
+    def _make_child_page(self):
+        """Create a live child page that can be deleted to trigger the signal."""
+        Locale.objects.get_or_create(language_code="en")
+        root = Page.objects.filter(depth=1).first()
+        if root is None:
+            root = Page.add_root(title="Root", slug="root-signal")
+        child = root.add_child(
+            instance=Page(title="Test Page", slug="test-page-signal-target")
+        )
+        return child
+
+    def test_page_delete_marks_related_scan_links_as_page_deleted(self):
+        scan = _make_scan(_make_site())
+        child = self._make_child_page()
+        link = _make_scan_link(scan, "https://example.com/test-page", page=child)
+
+        child.delete()
+
+        link.refresh_from_db()
+        assert link.page_deleted is True
+
+    def test_page_delete_stores_slug_on_related_scan_links(self):
+        scan = _make_scan(_make_site())
+        child = self._make_child_page()
+        slug = child.slug
+        link = _make_scan_link(scan, "https://example.com/test-page", page=child)
+
+        child.delete()
+
+        link.refresh_from_db()
+        assert link.page_slug == slug
+
+    def test_page_delete_does_not_affect_unrelated_scan_links(self):
+        scan = _make_scan(_make_site())
+        child = self._make_child_page()
+        unrelated_link = _make_scan_link(
+            scan, "https://example.com/unrelated", page=None
+        )
+
+        child.delete()
+
+        unrelated_link.refresh_from_db()
+        assert unrelated_link.page_deleted is False
+
+
+# ---------------------------------------------------------------------------
+# check_link_sync (tasks.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCheckLinkSync:
+    def test_broken_url_marks_scan_link_as_broken(self):
+        scan = _make_scan(_make_site())
+        link = _make_scan_link(scan, "https://example.com/broken-page")
+
+        with patch(
+            "app.wagtaillinkchecker.tasks.get_url",
+            return_value={
+                "error": True,
+                "invalid_schema": False,
+                "error_message": "Connection refused",
+                "status_code": None,
+            },
+        ):
+            from app.wagtaillinkchecker.tasks import check_link_sync
+
+            check_link_sync(link.pk)
+
+        link.refresh_from_db()
+        assert link.broken is True
+        assert link.error_text == "Connection refused"
+        assert link.crawled is True
+
+    def test_invalid_schema_url_marks_scan_link_as_invalid(self):
+        scan = _make_scan(_make_site())
+        link = _make_scan_link(scan, "tel:+15551234567")
+
+        with patch(
+            "app.wagtaillinkchecker.tasks.get_url",
+            return_value={"error": False, "invalid_schema": True},
+        ):
+            from app.wagtaillinkchecker.tasks import check_link_sync
+
+            check_link_sync(link.pk)
+
+        link.refresh_from_db()
+        assert link.invalid is True
+        assert link.broken is False
+        assert link.crawled is True
+
+    def test_successful_non_page_url_marks_scan_link_as_crawled_not_broken(self):
+        """An external URL that returns no error and is not a page URL is simply marked crawled."""
+        scan = _make_scan(_make_site())
+        link = _make_scan_link(scan, "https://external.com/resource", page=None)
+
+        mock_resp = MagicMock()
+        with patch(
+            "app.wagtaillinkchecker.tasks.get_url",
+            return_value={
+                "error": False,
+                "invalid_schema": False,
+                "response": mock_resp,
+            },
+        ):
+            from app.wagtaillinkchecker.tasks import check_link_sync
+
+            check_link_sync(link.pk)
+
+        link.refresh_from_db()
+        assert link.crawled is True
+        assert link.broken is False
+        assert link.invalid is False
+
+    def test_null_page_on_scan_link_does_not_raise_attribute_error(self):
+        """ScanLink with page=None must not raise AttributeError during the page-URL match check."""
+        scan = _make_scan(_make_site())
+        link = _make_scan_link(scan, "https://example.com/no-page", page=None)
+
+        mock_resp = MagicMock()
+        with patch(
+            "app.wagtaillinkchecker.tasks.get_url",
+            return_value={
+                "error": False,
+                "invalid_schema": False,
+                "response": mock_resp,
+            },
+        ):
+            from app.wagtaillinkchecker.tasks import check_link_sync
+
+            check_link_sync(link.pk)  # must not raise
+
+        link.refresh_from_db()
+        assert link.crawled is True
+
+    def test_mark_scan_complete_sets_scan_status_when_all_links_crawled(self):
+        from app.wagtaillinkchecker.models import Scan
+
+        scan = _make_scan(_make_site())
+        link = _make_scan_link(scan, "https://example.com/only-link", page=None)
+
+        mock_resp = MagicMock()
+        with patch(
+            "app.wagtaillinkchecker.tasks.get_url",
+            return_value={
+                "error": False,
+                "invalid_schema": False,
+                "response": mock_resp,
+            },
+        ):
+            from app.wagtaillinkchecker.tasks import check_link_sync
+
+            check_link_sync(link.pk, mark_scan_complete=True)
+
+        scan.refresh_from_db()
+        assert scan.status == Scan.Status.COMPLETED
+        assert scan.scan_finished is not None

--- a/website/tests/app/test_wagtaillinkchecker_models.py
+++ b/website/tests/app/test_wagtaillinkchecker_models.py
@@ -3,7 +3,8 @@
 import pytest
 from unittest.mock import patch, MagicMock
 from wagtail.models import Locale, Page, Site
-
+from app.wagtaillinkchecker.models import Scan, ScanLink
+from app.wagtaillinkchecker.tasks import check_link_sync
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -29,16 +30,12 @@ def _make_site():
 
 
 def _make_scan(site):
-    from app.wagtaillinkchecker.models import Scan
-
     return Scan.objects.create(site=site)
 
 
 def _make_scan_link(
     scan, url, *, broken=False, crawled=False, invalid=False, page=None
 ):
-    from app.wagtaillinkchecker.models import ScanLink
-
     return ScanLink.objects.create(
         scan=scan,
         url=url,
@@ -57,19 +54,16 @@ def _make_scan_link(
 @pytest.mark.django_db
 class TestScanIsFinished:
     def test_is_finished_returns_true_when_status_is_completed(self):
-        from app.wagtaillinkchecker.models import Scan
-
         scan = _make_scan(_make_site())
         scan.status = Scan.Status.COMPLETED
         assert scan.is_finished is True
 
     def test_is_finished_returns_false_when_status_is_running(self):
         scan = _make_scan(_make_site())
+        scan.status = Scan.Status.RUNNING
         assert scan.is_finished is False
 
     def test_is_finished_returns_false_when_status_is_failed(self):
-        from app.wagtaillinkchecker.models import Scan
-
         scan = _make_scan(_make_site())
         scan.status = Scan.Status.FAILED
         assert scan.is_finished is False
@@ -101,10 +95,31 @@ class TestScanLinkQuerySet:
             broken=True,
             crawled=True,
         )
-        return scan, working, broken, uncrawled, invalid, invalid_and_broken
+
+        broken_uncrawled = _make_scan_link(
+            scan, "https://example.com/broken-uncrawled", broken=True
+        )
+
+        return (
+            scan,
+            working,
+            broken,
+            uncrawled,
+            invalid,
+            invalid_and_broken,
+            broken_uncrawled,
+        )
 
     def test_valid_excludes_links_marked_invalid(self):
-        scan, working, broken, uncrawled, invalid, invalid_and_broken = self._setup()
+        (
+            scan,
+            working,
+            broken,
+            uncrawled,
+            invalid,
+            invalid_and_broken,
+            broken_uncrawled,
+        ) = self._setup()
         qs = scan.links.valid()
         assert invalid not in qs
         assert invalid_and_broken not in qs
@@ -117,19 +132,28 @@ class TestScanLinkQuerySet:
         assert uncrawled in qs
 
     def test_broken_links_returns_only_valid_broken_links(self):
-        scan, working, broken, uncrawled, invalid, invalid_and_broken = self._setup()
+        (
+            scan,
+            working,
+            broken,
+            uncrawled,
+            invalid,
+            invalid_and_broken,
+            broken_uncrawled,
+        ) = self._setup()
         qs = scan.links.broken_links()
         assert broken in qs
         assert working not in qs
+        assert broken_uncrawled in qs
 
     def test_broken_links_excludes_links_marked_as_invalid(self):
         """broken_links() chains through valid(), so a link with invalid=True is excluded even if broken=True."""
-        scan, *_, invalid_and_broken = self._setup()
+        scan, *_, invalid_and_broken, broken_uncrawled = self._setup()
         qs = scan.links.broken_links()
         assert invalid_and_broken not in qs
 
     def test_crawled_links_returns_valid_crawled_links(self):
-        scan, working, broken, uncrawled, invalid, _ = self._setup()
+        scan, working, broken, uncrawled, invalid, invalid_and_broken, _ = self._setup()
         qs = scan.links.crawled_links()
         assert working in qs
         assert broken in qs
@@ -137,7 +161,15 @@ class TestScanLinkQuerySet:
         assert invalid not in qs
 
     def test_invalid_links_returns_only_invalid_links(self):
-        scan, working, broken, uncrawled, invalid, invalid_and_broken = self._setup()
+        (
+            scan,
+            working,
+            broken,
+            uncrawled,
+            invalid,
+            invalid_and_broken,
+            broken_uncrawled,
+        ) = self._setup()
         qs = scan.links.invalid_links()
         assert invalid in qs
         assert invalid_and_broken in qs
@@ -145,7 +177,7 @@ class TestScanLinkQuerySet:
         assert broken not in qs
 
     def test_working_links_returns_valid_crawled_not_broken(self):
-        scan, working, broken, uncrawled, invalid, _ = self._setup()
+        scan, working, broken, uncrawled, invalid, invalid_and_broken, _ = self._setup()
         qs = scan.links.working_links()
         assert working in qs
         assert broken not in qs
@@ -166,20 +198,16 @@ class TestScanLinkQuerySet:
 
 
 class TestScanLinkPageIsDeleted:
-    def test_page_is_deleted_when_both_page_deleted_and_slug_are_set(self):
+    def test_page_is_deleted_returns_truthy_slug_when_both_are_set(self):
         # NOTE: page_is_deleted returns `self.page_deleted and self.page_slug`, so when
         # truthy the return value is the slug string, not the boolean True. Tests use
         # truthiness rather than identity to reflect actual behavior.
-        from app.wagtaillinkchecker.models import ScanLink
-
         link = ScanLink()
         link.page_deleted = True
         link.page_slug = "some-slug"
         assert link.page_is_deleted
 
     def test_page_is_not_deleted_when_page_deleted_is_false(self):
-        from app.wagtaillinkchecker.models import ScanLink
-
         link = ScanLink()
         link.page_deleted = False
         link.page_slug = "some-slug"
@@ -187,8 +215,6 @@ class TestScanLinkPageIsDeleted:
 
     def test_page_is_not_deleted_when_slug_is_none(self):
         # NOTE: returns None (not False) when slug is absent — see comment above.
-        from app.wagtaillinkchecker.models import ScanLink
-
         link = ScanLink()
         link.page_deleted = True
         link.page_slug = None
@@ -267,8 +293,6 @@ class TestCheckLinkSync:
                 "status_code": None,
             },
         ):
-            from app.wagtaillinkchecker.tasks import check_link_sync
-
             check_link_sync(link.pk)
 
         link.refresh_from_db()
@@ -284,8 +308,6 @@ class TestCheckLinkSync:
             "app.wagtaillinkchecker.tasks.get_url",
             return_value={"error": False, "invalid_schema": True},
         ):
-            from app.wagtaillinkchecker.tasks import check_link_sync
-
             check_link_sync(link.pk)
 
         link.refresh_from_db()
@@ -307,8 +329,6 @@ class TestCheckLinkSync:
                 "response": mock_resp,
             },
         ):
-            from app.wagtaillinkchecker.tasks import check_link_sync
-
             check_link_sync(link.pk)
 
         link.refresh_from_db()
@@ -316,30 +336,7 @@ class TestCheckLinkSync:
         assert link.broken is False
         assert link.invalid is False
 
-    def test_null_page_on_scan_link_does_not_raise_attribute_error(self):
-        """ScanLink with page=None must not raise AttributeError during the page-URL match check."""
-        scan = _make_scan(_make_site())
-        link = _make_scan_link(scan, "https://example.com/no-page", page=None)
-
-        mock_resp = MagicMock()
-        with patch(
-            "app.wagtaillinkchecker.tasks.get_url",
-            return_value={
-                "error": False,
-                "invalid_schema": False,
-                "response": mock_resp,
-            },
-        ):
-            from app.wagtaillinkchecker.tasks import check_link_sync
-
-            check_link_sync(link.pk)  # must not raise
-
-        link.refresh_from_db()
-        assert link.crawled is True
-
     def test_mark_scan_complete_sets_scan_status_when_all_links_crawled(self):
-        from app.wagtaillinkchecker.models import Scan
-
         scan = _make_scan(_make_site())
         link = _make_scan_link(scan, "https://example.com/only-link", page=None)
 
@@ -352,8 +349,6 @@ class TestCheckLinkSync:
                 "response": mock_resp,
             },
         ):
-            from app.wagtaillinkchecker.tasks import check_link_sync
-
             check_link_sync(link.pk, mark_scan_complete=True)
 
         scan.refresh_from_db()

--- a/website/tests/app/test_wagtaillinkchecker_scanner.py
+++ b/website/tests/app/test_wagtaillinkchecker_scanner.py
@@ -1,0 +1,365 @@
+"""Tests for app/wagtaillinkchecker/scanner.py"""
+
+from unittest.mock import patch, MagicMock
+import requests as requests_lib
+
+
+def _make_mock_site(root_url="https://example.com"):
+    site = MagicMock()
+    site.root_url = root_url
+    return site
+
+
+def _make_response(status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Link class
+# ---------------------------------------------------------------------------
+
+
+class TestLinkMessage:
+    def test_error_attribute_is_returned_directly(self):
+        """When Link.error is set, Link.message returns it verbatim without inspecting status_code."""
+        from app.wagtaillinkchecker.scanner import Link
+
+        link = Link(url="https://example.com", page=None, error="Custom error message")
+        assert link.message == "Custom error message"
+
+    def test_success_message_for_2xx_status_code(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        link = Link(url="https://example.com", page=None, status_code=200)
+        assert link.message == "Success"
+
+    def test_success_message_for_1xx_status_code(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        link = Link(url="https://example.com", page=None, status_code=100)
+        assert link.message == "Success"
+
+    def test_5xx_on_own_site_url_returns_admin_notification_message(self):
+        """5xx responses for internal (same-site) URLs produce a friendlier admin-oriented message."""
+        from app.wagtaillinkchecker.scanner import Link
+
+        site = _make_mock_site("https://example.com")
+        link = Link(
+            url="https://example.com/internal-page",
+            page=None,
+            status_code=500,
+            site=site,
+        )
+        assert "500" in link.message
+        assert "Internal server error" in link.message
+
+    def test_5xx_on_external_url_returns_standard_http_message(self):
+        """5xx responses for external URLs fall through to the standard http.client response text."""
+        from app.wagtaillinkchecker.scanner import Link
+
+        site = _make_mock_site("https://example.com")
+        link = Link(
+            url="https://external.com/page",
+            page=None,
+            status_code=500,
+            site=site,
+        )
+        assert "500" in link.message
+        assert "Internal Server Error" in link.message
+
+    def test_known_4xx_status_code_returns_http_standard_message(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        link = Link(url="https://example.com", page=None, status_code=404)
+        assert "404" in link.message
+        assert "Not Found" in link.message
+
+    def test_unrecognized_status_code_returns_unknown_error_message(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        link = Link(url="https://example.com", page=None, status_code=999)
+        assert "999" in link.message
+        assert "Unknown error" in link.message
+
+
+class TestLinkIdentity:
+    def test_str_returns_url(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        link = Link(url="https://example.com", page=None)
+        assert str(link) == "https://example.com"
+
+    def test_links_with_same_url_are_equal(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        a = Link(url="https://example.com", page=None)
+        b = Link(url="https://example.com", page=None)
+        assert a == b
+
+    def test_links_with_different_urls_are_not_equal(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        a = Link(url="https://example.com", page=None)
+        b = Link(url="https://other.com", page=None)
+        assert a != b
+
+    def test_hash_is_derived_from_url(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        link = Link(url="https://example.com", page=None)
+        assert hash(link) == hash("https://example.com")
+
+    def test_equality_with_non_link_returns_not_implemented(self):
+        from app.wagtaillinkchecker.scanner import Link
+
+        link = Link(url="https://example.com", page=None)
+        assert link.__eq__("not a link") is NotImplemented
+
+
+# ---------------------------------------------------------------------------
+# get_url()
+# ---------------------------------------------------------------------------
+
+
+class TestGetUrl:
+    def test_successful_get_request_returns_response(self):
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        mock_resp = _make_response(200)
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get", return_value=mock_resp
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["error"] is False
+        assert result["response"] is mock_resp
+
+    def test_successful_head_request_returns_response(self):
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        mock_resp = _make_response(200)
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.head", return_value=mock_resp
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=False
+            )
+        assert result["error"] is False
+        assert result["response"] is mock_resp
+
+    def test_head_falls_back_to_get_on_4xx_response(self):
+        """A 4xx HEAD response retries with a full GET to avoid false positives from servers that block HEAD."""
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with (
+            patch(
+                "app.wagtaillinkchecker.scanner.requests.head",
+                return_value=_make_response(404),
+            ),
+            patch(
+                "app.wagtaillinkchecker.scanner.requests.get",
+                return_value=_make_response(200),
+            ),
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=False
+            )
+        assert result["error"] is False
+
+    def test_get_sets_error_with_known_message_for_4xx(self):
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get",
+            return_value=_make_response(404),
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["error"] is True
+        assert result["status_code"] == 404
+        assert "Not Found" in result["error_message"]
+
+    def test_get_sets_client_error_message_for_unmapped_4xx(self):
+        """A 4xx code absent from HTTP_STATUS_CODES falls back to a generic 'Client error' message."""
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get",
+            return_value=_make_response(490),  # not in HTTP_STATUS_CODES
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["error"] is True
+        assert result["error_message"] == "Client error"
+
+    def test_get_sets_server_error_message_for_unmapped_5xx(self):
+        """A 5xx code absent from HTTP_STATUS_CODES falls back to a generic 'Server Error' message."""
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get",
+            return_value=_make_response(520),  # not in HTTP_STATUS_CODES
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["error"] is True
+        assert result["error_message"] == "Server Error"
+
+    def test_get_sets_unknown_status_message_for_out_of_range_code(self):
+        """A status code outside 400-599 (e.g. 600) uses the 'Unknown HTTP Status Code' fallback."""
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get",
+            return_value=_make_response(600),
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["error"] is True
+        assert "600" in result["error_message"]
+
+    def test_head_falls_back_to_get_on_connection_error(self):
+        """A ConnectionError on HEAD retries with a full GET before reporting failure."""
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with (
+            patch(
+                "app.wagtaillinkchecker.scanner.requests.head",
+                side_effect=requests_lib.exceptions.ConnectionError,
+            ),
+            patch(
+                "app.wagtaillinkchecker.scanner.requests.get",
+                return_value=_make_response(200),
+            ),
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=False
+            )
+        assert result["error"] is False
+
+    def test_get_sets_error_on_connection_error(self):
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get",
+            side_effect=requests_lib.exceptions.ConnectionError,
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["error"] is True
+        assert "connecting" in result["error_message"]
+
+    def test_head_falls_back_to_get_on_invalid_schema(self):
+        """An InvalidSchema on HEAD retries with GET, which may succeed for schemas requests can handle."""
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with (
+            patch(
+                "app.wagtaillinkchecker.scanner.requests.head",
+                side_effect=requests_lib.exceptions.InvalidSchema,
+            ),
+            patch(
+                "app.wagtaillinkchecker.scanner.requests.get",
+                return_value=_make_response(200),
+            ),
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=False
+            )
+        assert result["invalid_schema"] is False
+        assert result["error"] is False
+
+    def test_get_sets_invalid_schema_flag_on_invalid_schema(self):
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get",
+            side_effect=requests_lib.exceptions.InvalidSchema,
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["invalid_schema"] is True
+        assert result["error"] is False
+
+    def test_get_sets_error_on_generic_request_exception(self):
+        """A RequestException that is not ConnectionError or InvalidSchema sets error=True."""
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get",
+            side_effect=requests_lib.exceptions.Timeout,
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["error"] is True
+        assert "Timeout" in result["error_message"]
+
+    def test_get_sets_none_status_code_when_exception_raised_before_response(self):
+        """When a RequestException is raised before any response is received, status_code is None."""
+        from app.wagtaillinkchecker.scanner import get_url
+
+        site = _make_mock_site()
+        with patch(
+            "app.wagtaillinkchecker.scanner.requests.get",
+            side_effect=requests_lib.exceptions.Timeout,
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=True
+            )
+        assert result["status_code"] is None
+
+
+# ---------------------------------------------------------------------------
+# clean_url()
+# ---------------------------------------------------------------------------
+
+
+class TestCleanUrl:
+    def test_relative_url_is_prefixed_with_site_root_url(self):
+        from app.wagtaillinkchecker.scanner import clean_url
+
+        site = _make_mock_site("https://example.com")
+        assert clean_url("/about", site) == "https://example.com/about"
+
+    def test_absolute_url_is_returned_unchanged(self):
+        from app.wagtaillinkchecker.scanner import clean_url
+
+        site = _make_mock_site("https://example.com")
+        assert clean_url("https://other.com/page", site) == "https://other.com/page"
+
+    def test_hash_anchor_returns_none(self):
+        from app.wagtaillinkchecker.scanner import clean_url
+
+        assert clean_url("#", _make_mock_site()) is None
+
+    def test_none_input_returns_none(self):
+        from app.wagtaillinkchecker.scanner import clean_url
+
+        assert clean_url(None, _make_mock_site()) is None
+
+    def test_empty_string_returns_none(self):
+        from app.wagtaillinkchecker.scanner import clean_url
+
+        assert clean_url("", _make_mock_site()) is None

--- a/website/tests/app/test_wagtaillinkchecker_scanner.py
+++ b/website/tests/app/test_wagtaillinkchecker_scanner.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch, MagicMock
 import requests as requests_lib
+from app.wagtaillinkchecker.scanner import Link, get_url, clean_url
 
 
 def _make_mock_site(root_url="https://example.com"):
@@ -24,26 +25,20 @@ def _make_response(status_code=200):
 class TestLinkMessage:
     def test_error_attribute_is_returned_directly(self):
         """When Link.error is set, Link.message returns it verbatim without inspecting status_code."""
-        from app.wagtaillinkchecker.scanner import Link
 
         link = Link(url="https://example.com", page=None, error="Custom error message")
         assert link.message == "Custom error message"
 
     def test_success_message_for_2xx_status_code(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         link = Link(url="https://example.com", page=None, status_code=200)
         assert link.message == "Success"
 
     def test_success_message_for_1xx_status_code(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         link = Link(url="https://example.com", page=None, status_code=100)
         assert link.message == "Success"
 
     def test_5xx_on_own_site_url_returns_admin_notification_message(self):
         """5xx responses for internal (same-site) URLs produce a friendlier admin-oriented message."""
-        from app.wagtaillinkchecker.scanner import Link
 
         site = _make_mock_site("https://example.com")
         link = Link(
@@ -57,7 +52,6 @@ class TestLinkMessage:
 
     def test_5xx_on_external_url_returns_standard_http_message(self):
         """5xx responses for external URLs fall through to the standard http.client response text."""
-        from app.wagtaillinkchecker.scanner import Link
 
         site = _make_mock_site("https://example.com")
         link = Link(
@@ -70,15 +64,11 @@ class TestLinkMessage:
         assert "Internal Server Error" in link.message
 
     def test_known_4xx_status_code_returns_http_standard_message(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         link = Link(url="https://example.com", page=None, status_code=404)
         assert "404" in link.message
         assert "Not Found" in link.message
 
     def test_unrecognized_status_code_returns_unknown_error_message(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         link = Link(url="https://example.com", page=None, status_code=999)
         assert "999" in link.message
         assert "Unknown error" in link.message
@@ -86,34 +76,24 @@ class TestLinkMessage:
 
 class TestLinkIdentity:
     def test_str_returns_url(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         link = Link(url="https://example.com", page=None)
         assert str(link) == "https://example.com"
 
     def test_links_with_same_url_are_equal(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         a = Link(url="https://example.com", page=None)
         b = Link(url="https://example.com", page=None)
         assert a == b
 
     def test_links_with_different_urls_are_not_equal(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         a = Link(url="https://example.com", page=None)
         b = Link(url="https://other.com", page=None)
         assert a != b
 
     def test_hash_is_derived_from_url(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         link = Link(url="https://example.com", page=None)
         assert hash(link) == hash("https://example.com")
 
     def test_equality_with_non_link_returns_not_implemented(self):
-        from app.wagtaillinkchecker.scanner import Link
-
         link = Link(url="https://example.com", page=None)
         assert link.__eq__("not a link") is NotImplemented
 
@@ -125,8 +105,6 @@ class TestLinkIdentity:
 
 class TestGetUrl:
     def test_successful_get_request_returns_response(self):
-        from app.wagtaillinkchecker.scanner import get_url
-
         site = _make_mock_site()
         mock_resp = _make_response(200)
         with patch(
@@ -139,8 +117,6 @@ class TestGetUrl:
         assert result["response"] is mock_resp
 
     def test_successful_head_request_returns_response(self):
-        from app.wagtaillinkchecker.scanner import get_url
-
         site = _make_mock_site()
         mock_resp = _make_response(200)
         with patch(
@@ -154,7 +130,6 @@ class TestGetUrl:
 
     def test_head_falls_back_to_get_on_4xx_response(self):
         """A 4xx HEAD response retries with a full GET to avoid false positives from servers that block HEAD."""
-        from app.wagtaillinkchecker.scanner import get_url
 
         site = _make_mock_site()
         with (
@@ -173,8 +148,6 @@ class TestGetUrl:
         assert result["error"] is False
 
     def test_get_sets_error_with_known_message_for_4xx(self):
-        from app.wagtaillinkchecker.scanner import get_url
-
         site = _make_mock_site()
         with patch(
             "app.wagtaillinkchecker.scanner.requests.get",
@@ -189,7 +162,6 @@ class TestGetUrl:
 
     def test_get_sets_client_error_message_for_unmapped_4xx(self):
         """A 4xx code absent from HTTP_STATUS_CODES falls back to a generic 'Client error' message."""
-        from app.wagtaillinkchecker.scanner import get_url
 
         site = _make_mock_site()
         with patch(
@@ -204,7 +176,6 @@ class TestGetUrl:
 
     def test_get_sets_server_error_message_for_unmapped_5xx(self):
         """A 5xx code absent from HTTP_STATUS_CODES falls back to a generic 'Server Error' message."""
-        from app.wagtaillinkchecker.scanner import get_url
 
         site = _make_mock_site()
         with patch(
@@ -219,7 +190,6 @@ class TestGetUrl:
 
     def test_get_sets_unknown_status_message_for_out_of_range_code(self):
         """A status code outside 400-599 (e.g. 600) uses the 'Unknown HTTP Status Code' fallback."""
-        from app.wagtaillinkchecker.scanner import get_url
 
         site = _make_mock_site()
         with patch(
@@ -234,7 +204,11 @@ class TestGetUrl:
 
     def test_head_falls_back_to_get_on_connection_error(self):
         """A ConnectionError on HEAD retries with a full GET before reporting failure."""
-        from app.wagtaillinkchecker.scanner import get_url
+        # From Claude: ConnectionError is raised when the TCP connection can't be established
+        # (DNS failure, host unreachable, connection refused). These conditions apply at the
+        # OS network layer — they affect both HEAD and GET for the same host at the same instant.
+        # Mocking HEAD to fail with ConnectionError and GET to immediately return 200 is a
+        # scenario that can't occur in production.
 
         site = _make_mock_site()
         with (
@@ -252,9 +226,33 @@ class TestGetUrl:
             )
         assert result["error"] is False
 
-    def test_get_sets_error_on_connection_error(self):
-        from app.wagtaillinkchecker.scanner import get_url
+    def test_head_falls_back_to_get_on_connection_error_that_also_errors(self):
+        """A ConnectionError on HEAD retries with a full GET before reporting failure."""
+        # From Claude: ConnectionError is raised when the TCP connection can't be established
+        # (DNS failure, host unreachable, connection refused). These conditions apply at the
+        # OS network layer — they affect both HEAD and GET for the same host at the same instant.
 
+        # Mocking HEAD to fail with ConnectionError and GET to also fail with ConnectionError
+        # is a scenario that can occur in production.
+
+        site = _make_mock_site()
+        with (
+            patch(
+                "app.wagtaillinkchecker.scanner.requests.head",
+                side_effect=requests_lib.exceptions.ConnectionError,
+            ),
+            patch(
+                "app.wagtaillinkchecker.scanner.requests.get",
+                side_effect=requests_lib.exceptions.ConnectionError,
+            ),
+        ):
+            result = get_url(
+                "https://example.com", page=None, site=site, get_full_result=False
+            )
+        assert result["error"] is True
+        assert "connecting" in str(result["error_message"])
+
+    def test_get_sets_error_on_connection_error(self):
         site = _make_mock_site()
         with patch(
             "app.wagtaillinkchecker.scanner.requests.get",
@@ -264,11 +262,10 @@ class TestGetUrl:
                 "https://example.com", page=None, site=site, get_full_result=True
             )
         assert result["error"] is True
-        assert "connecting" in result["error_message"]
+        assert "connecting" in str(result["error_message"])
 
     def test_head_falls_back_to_get_on_invalid_schema(self):
         """An InvalidSchema on HEAD retries with GET, which may succeed for schemas requests can handle."""
-        from app.wagtaillinkchecker.scanner import get_url
 
         site = _make_mock_site()
         with (
@@ -282,28 +279,25 @@ class TestGetUrl:
             ),
         ):
             result = get_url(
-                "https://example.com", page=None, site=site, get_full_result=False
+                "tel://123-456-7890", page=None, site=site, get_full_result=False
             )
         assert result["invalid_schema"] is False
         assert result["error"] is False
 
     def test_get_sets_invalid_schema_flag_on_invalid_schema(self):
-        from app.wagtaillinkchecker.scanner import get_url
-
         site = _make_mock_site()
         with patch(
             "app.wagtaillinkchecker.scanner.requests.get",
             side_effect=requests_lib.exceptions.InvalidSchema,
         ):
             result = get_url(
-                "https://example.com", page=None, site=site, get_full_result=True
+                "tel://123-456-7890", page=None, site=site, get_full_result=True
             )
         assert result["invalid_schema"] is True
         assert result["error"] is False
 
     def test_get_sets_error_on_generic_request_exception(self):
         """A RequestException that is not ConnectionError or InvalidSchema sets error=True."""
-        from app.wagtaillinkchecker.scanner import get_url
 
         site = _make_mock_site()
         with patch(
@@ -315,19 +309,6 @@ class TestGetUrl:
             )
         assert result["error"] is True
         assert "Timeout" in result["error_message"]
-
-    def test_get_sets_none_status_code_when_exception_raised_before_response(self):
-        """When a RequestException is raised before any response is received, status_code is None."""
-        from app.wagtaillinkchecker.scanner import get_url
-
-        site = _make_mock_site()
-        with patch(
-            "app.wagtaillinkchecker.scanner.requests.get",
-            side_effect=requests_lib.exceptions.Timeout,
-        ):
-            result = get_url(
-                "https://example.com", page=None, site=site, get_full_result=True
-            )
         assert result["status_code"] is None
 
 
@@ -338,28 +319,18 @@ class TestGetUrl:
 
 class TestCleanUrl:
     def test_relative_url_is_prefixed_with_site_root_url(self):
-        from app.wagtaillinkchecker.scanner import clean_url
-
         site = _make_mock_site("https://example.com")
         assert clean_url("/about", site) == "https://example.com/about"
 
     def test_absolute_url_is_returned_unchanged(self):
-        from app.wagtaillinkchecker.scanner import clean_url
-
         site = _make_mock_site("https://example.com")
         assert clean_url("https://other.com/page", site) == "https://other.com/page"
 
     def test_hash_anchor_returns_none(self):
-        from app.wagtaillinkchecker.scanner import clean_url
-
         assert clean_url("#", _make_mock_site()) is None
 
     def test_none_input_returns_none(self):
-        from app.wagtaillinkchecker.scanner import clean_url
-
         assert clean_url(None, _make_mock_site()) is None
 
     def test_empty_string_returns_none(self):
-        from app.wagtaillinkchecker.scanner import clean_url
-
         assert clean_url("", _make_mock_site()) is None


### PR DESCRIPTION
## Summary

- Adds `tests/app/test_wagtaillinkchecker_scanner.py` — 30 tests covering `Link.message` branching, `get_url()` success/error/fallback paths, and `clean_url()`
- Adds `tests/app/test_wagtaillinkchecker_models.py` — 22 tests covering `Scan.is_finished`, `ScanLinkQuerySet` methods, the `delete_tag` signal, and `check_link_sync()` state transitions
- Surfaces one behavior worth a follow-up: `ScanLink.page_is_deleted` returns the slug string (or `None`) rather than a strict `bool` — documented in test comments, not fixed here

## Test plan

- [ ] `pytest tests/app/test_wagtaillinkchecker_scanner.py tests/app/test_wagtaillinkchecker_models.py` — 52 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)