### PR TITLE
WAG-1261: Fix multi-line secret detection so it actually runs in the real scan pipeline

### DIFF
--- a/website/detect_secrets_plugins/keywords.py
+++ b/website/detect_secrets_plugins/keywords.py
@@ -1,7 +1,21 @@
 import re
-from typing import IO, Any, Generator
+from typing import Any, Generator, Optional
 
+from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.base import BasePlugin
+from detect_secrets.util.code_snippet import CodeSnippet
+
+_KEYWORD = r"(?:[A-Z0-9]+_)*(?:KEY|TOKEN|AUTH|CREDENTIAL|CREDENTIALS|OAUTH|SIGNATURE)"
+
+_STRING_PARTS = re.compile(r'["\']([^"\']*)["\']')
+
+
+def _extract_quoted(match: "re.Match") -> Optional[str]:
+    return next((g for g in match.groups() if g is not None), None)
+
+
+def _extract_paren_concat(match: "re.Match") -> Optional[str]:
+    return "".join(_STRING_PARTS.findall(match.group(1)))
 
 
 class BroadKeywordDetector(BasePlugin):
@@ -21,90 +35,99 @@ class BroadKeywordDetector(BasePlugin):
     Multi-line detection:
     - Triple-quoted strings: KEY = \"""...\"""  (may span lines)
     - Parenthesized implicit concatenation: KEY = (\\n    "part1"\\n    "part2"\\n)
+
+    NOTE ON MULTI-LINE DETECTION: detect-secrets' scan pipeline
+    (scan_file/scan_diff) only ever calls `analyze_line`, one physical line
+    at a time - there is no "whole file" hook a plugin can implement. The
+    only cross-line information available is the `context` (CodeSnippet)
+    argument `analyze_line` optionally receives: a window of a few lines
+    before/after the current one. `analyze_line` below uses that window to
+    catch secrets split across lines, reporting a match only on the call
+    whose `line_number` is the line the match starts on (so it isn't
+    reported once per overlapping line). This logic is intentionally
+    duplicated in wagtail_transfer.py rather than shared, because
+    detect-secrets loads each `--plugin <file>` in isolation via
+    importlib (see `import_file_as_module`), without adding this
+    directory to `sys.path` - a cross-file import here would only work
+    by accident (e.g. under pytest, which happens to put `website/` on
+    `sys.path`) and would break the real pre-commit hook.
     """
 
     secret_type = "Broad Secret Keyword"  # pragma: allowlist secret
+    min_secret_length = 8
 
     # Single-line: KEYWORD = "value" or 'value' (>= 8 chars, case-sensitive)
     PATTERN = re.compile(  # pragma: allowlist secret
-        r"(?<![a-zA-Z])"
-        r"(?:[A-Z0-9]+_)*"
-        r"(?:KEY|TOKEN|AUTH|CREDENTIAL|CREDENTIALS|OAUTH|SIGNATURE)"
-        r"\s*=\s*"
-        r'["\']([^"\']{8,})["\']',
+        rf"(?<![a-zA-Z]){_KEYWORD}\s*=\s*" r'["\']([^"\']{8,})["\']',
     )
 
-    # Triple-quoted assignment — used by analyze_file for multi-line spans.
+    # Triple-quoted assignment, possibly spanning multiple lines.
     _TRIPLE_QUOTE = re.compile(  # pragma: allowlist secret
-        r"(?<![a-zA-Z])"
-        r"(?:[A-Z0-9]+_)*"
-        r"(?:KEY|TOKEN|AUTH|CREDENTIAL|CREDENTIALS|OAUTH|SIGNATURE)"
-        r"\s*=\s*"
-        r'(?:"""(.*?)"""|\'\'\'(.*?)\'\'\')',
+        rf'(?<![a-zA-Z]){_KEYWORD}\s*=\s*(?:"""(.*?)"""|\'\'\'(.*?)\'\'\')',
         re.DOTALL,
     )
 
-    # Parenthesized implicit string concatenation across lines.
+    # Parenthesized implicit string concatenation, possibly spanning multiple lines.
     _PAREN_CONCAT = re.compile(  # pragma: allowlist secret
-        r"(?<![a-zA-Z])"
-        r"(?:[A-Z0-9]+_)*"
-        r"(?:KEY|TOKEN|AUTH|CREDENTIAL|CREDENTIALS|OAUTH|SIGNATURE)"
-        r"\s*=\s*"
-        r'\(\s*((?:["\'][^"\']*["\'][\s\\]*)+)\s*\)',
+        rf'(?<![a-zA-Z]){_KEYWORD}\s*=\s*\(\s*((?:["\'][^"\']*["\'][\s\\]*)+)\s*\)',
         re.DOTALL,
     )
 
-    _STRING_PARTS = re.compile(r'["\']([^"\']*)["\']')
+    multiline_patterns = (
+        (_TRIPLE_QUOTE, _extract_quoted),
+        (_PAREN_CONCAT, _extract_paren_concat),
+    )
 
     def analyze_string(self, line: str, **kwargs: Any) -> Generator[str, None, None]:
         for match in self.PATTERN.finditer(line):
             yield match.group(1)
 
-    def analyze_file(self, f: IO) -> Generator[Any, None, None]:
-        from detect_secrets.core.potential_secret import PotentialSecret
+    def analyze_line(
+        self,
+        filename: str,
+        line: str,
+        line_number: int = 0,
+        context: Optional[CodeSnippet] = None,
+        **kwargs: Any,
+    ) -> set:
+        output = super().analyze_line(
+            filename=filename,
+            line=line,
+            line_number=line_number,
+            context=context,  # type: ignore[arg-type]  # BasePlugin's stub omits Optional
+            **kwargs,
+        )
 
-        lines = f.readlines()
+        if context is not None:
+            content = "".join(context.lines)
+            for pattern, extract in self.multiline_patterns:
+                for match in pattern.finditer(content):
+                    if "\n" not in match.group(0):
+                        continue  # Single-line match; analyze_string already covers this.
 
-        # Per-line analysis via analyze_line so # pragma: allowlist secret is honoured.
-        for line_number, line in enumerate(lines, start=1):
-            yield from self.analyze_line(
-                filename=f.name,
-                line=line,
-                line_number=line_number,
-            )
+                    match_line_number = (
+                        context.start_line + 1 + content[: match.start()].count("\n")
+                    )
+                    if match_line_number != line_number:
+                        continue  # Only report once, on the call for the starting line.
 
-        content = "".join(lines)
+                    secret = extract(match)
+                    if secret is None:
+                        continue
+                    secret = secret.strip()
+                    if len(secret) < self.min_secret_length:
+                        continue
 
-        # Triple-quoted strings that span more than one line.
-        for match in self._TRIPLE_QUOTE.finditer(content):
-            if "\n" not in match.group(0):
-                continue  # Single-line triple-quoted; already caught above.
-            secret = next(g for g in match.groups() if g is not None).strip()
-            if len(secret) < 8:
-                continue
-            line_number = content[: match.start()].count("\n") + 1
-            yield PotentialSecret(
-                type=self.secret_type,
-                filename=f.name,
-                secret=secret,
-                line_number=line_number,
-            )
+                    output.add(
+                        PotentialSecret(
+                            type=self.secret_type,
+                            filename=filename,
+                            secret=secret,
+                            line_number=line_number,
+                        ),
+                    )
 
-        # Parenthesized implicit concatenation that spans more than one line.
-        for match in self._PAREN_CONCAT.finditer(content):
-            if "\n" not in match.group(0):
-                continue  # Single-line paren; already caught above.
-            parts = self._STRING_PARTS.findall(match.group(1))
-            secret = "".join(parts)
-            if len(secret) < 8:
-                continue
-            line_number = content[: match.start()].count("\n") + 1
-            yield PotentialSecret(
-                type=self.secret_type,
-                filename=f.name,
-                secret=secret,
-                line_number=line_number,
-            )
+        return output
 
     def json(self) -> dict[str, Any]:
         return {"name": self.__class__.__name__}

--- a/website/detect_secrets_plugins/wagtail_transfer.py
+++ b/website/detect_secrets_plugins/wagtail_transfer.py
@@ -1,13 +1,37 @@
 import re
-from typing import IO, Any, Generator
+from typing import Any, Generator, Optional
 
+from detect_secrets.core.potential_secret import PotentialSecret
 from detect_secrets.plugins.base import BasePlugin
+from detect_secrets.util.code_snippet import CodeSnippet
+
+
+def _extract_quoted(match: "re.Match") -> Optional[str]:
+    return next((g for g in match.groups() if g is not None), None)
 
 
 class WagtailTransferSecretKeyDetector(BasePlugin):
-    """Detects hardcoded WAGTAILTRANSFER_SECRET_KEY values."""
+    """Detects hardcoded WAGTAILTRANSFER_SECRET_KEY values.
+
+    NOTE ON MULTI-LINE DETECTION: detect-secrets' scan pipeline
+    (scan_file/scan_diff) only ever calls `analyze_line`, one physical line
+    at a time - there is no "whole file" hook a plugin can implement. The
+    only cross-line information available is the `context` (CodeSnippet)
+    argument `analyze_line` optionally receives: a window of a few lines
+    before/after the current one. `analyze_line` below uses that window to
+    catch secrets split across lines (e.g. triple-quoted strings), reporting
+    a match only on the call whose `line_number` is the line the match
+    starts on (so it isn't reported once per overlapping line). This logic
+    is intentionally duplicated in keywords.py rather than shared, because
+    detect-secrets loads each `--plugin <file>` in isolation via importlib
+    (see `import_file_as_module`), without adding this directory to
+    `sys.path` - a cross-file import here would only work by accident (e.g.
+    under pytest, which happens to put `website/` on `sys.path`) and would
+    break the real pre-commit hook.
+    """
 
     secret_type = "Wagtail Transfer Secret Key"  # pragma: allowlist secret
+    min_secret_length = 8
 
     # Matches: WAGTAILTRANSFER_SECRET_KEY = "some-value" or 'some-value'  # pragma: allowlist secret
     WAGTAIL_TRANSFER_KEY_PATTERN = re.compile(  # pragma: allowlist secret
@@ -15,44 +39,64 @@ class WagtailTransferSecretKeyDetector(BasePlugin):
         re.IGNORECASE,
     )
 
-    # Triple-quoted assignment — used by analyze_file for multi-line spans.
+    # Triple-quoted assignment, possibly spanning multiple lines.
     _TRIPLE_QUOTE = re.compile(  # pragma: allowlist secret
         r'WAGTAILTRANSFER_SECRET_KEY\s*=\s*(?:"""(.*?)"""|\'\'\'(.*?)\'\'\')',
         re.DOTALL | re.IGNORECASE,
     )
 
+    multiline_patterns = ((_TRIPLE_QUOTE, _extract_quoted),)
+
     def analyze_string(self, line: str, **kwargs: Any) -> Generator[str, None, None]:
         for match in self.WAGTAIL_TRANSFER_KEY_PATTERN.finditer(line):
             yield match.group(1)
 
-    def analyze_file(self, f: IO) -> Generator[Any, None, None]:
-        from detect_secrets.core.potential_secret import PotentialSecret
+    def analyze_line(
+        self,
+        filename: str,
+        line: str,
+        line_number: int = 0,
+        context: Optional[CodeSnippet] = None,
+        **kwargs: Any,
+    ) -> set:
+        output = super().analyze_line(
+            filename=filename,
+            line=line,
+            line_number=line_number,
+            context=context,  # type: ignore[arg-type]  # BasePlugin's stub omits Optional
+            **kwargs,
+        )
 
-        lines = f.readlines()
+        if context is not None:
+            content = "".join(context.lines)
+            for pattern, extract in self.multiline_patterns:
+                for match in pattern.finditer(content):
+                    if "\n" not in match.group(0):
+                        continue  # Single-line match; analyze_string already covers this.
 
-        # Per-line analysis via analyze_line so # pragma: allowlist secret is honoured.
-        for line_number, line in enumerate(lines, start=1):
-            yield from self.analyze_line(
-                filename=f.name,
-                line=line,
-                line_number=line_number,
-            )
+                    match_line_number = (
+                        context.start_line + 1 + content[: match.start()].count("\n")
+                    )
+                    if match_line_number != line_number:
+                        continue  # Only report once, on the call for the starting line.
 
-        # Triple-quoted strings that span more than one line.
-        content = "".join(lines)
-        for match in self._TRIPLE_QUOTE.finditer(content):
-            if "\n" not in match.group(0):
-                continue  # Single-line triple-quoted; already caught above.
-            secret = next(g for g in match.groups() if g is not None).strip()
-            if len(secret) < 8:
-                continue
-            line_number = content[: match.start()].count("\n") + 1
-            yield PotentialSecret(
-                type=self.secret_type,
-                filename=f.name,
-                secret=secret,
-                line_number=line_number,
-            )
+                    secret = extract(match)
+                    if secret is None:
+                        continue
+                    secret = secret.strip()
+                    if len(secret) < self.min_secret_length:
+                        continue
+
+                    output.add(
+                        PotentialSecret(
+                            type=self.secret_type,
+                            filename=filename,
+                            secret=secret,
+                            line_number=line_number,
+                        ),
+                    )
+
+        return output
 
     def json(self) -> dict[str, Any]:
         return {"name": self.__class__.__name__}

--- a/website/tests/test_broad_keyword_detector.py
+++ b/website/tests/test_broad_keyword_detector.py
@@ -1,7 +1,7 @@
-import io
 from pathlib import Path
 
 import pytest
+from detect_secrets.core.plugins.util import get_mapping_from_secret_type_to_class
 from detect_secrets.core.scan import scan_file
 from detect_secrets.settings import transient_settings
 
@@ -15,12 +15,6 @@ _PLUGIN_FILE = (
 )
 
 
-class _NamedIO(io.StringIO):
-    """StringIO with a name attribute so analyze_file can reference the filename."""
-
-    name = "<test>"
-
-
 @pytest.fixture
 def detector():
     return BroadKeywordDetector()
@@ -30,8 +24,28 @@ def _caught(detector, line):
     return list(detector.analyze_string(line))
 
 
-def _caught_in_file(detector, content):
-    return list(detector.analyze_file(_NamedIO(content)))
+def _scan(tmp_path, content):
+    """Scan `content` through the real detect-secrets pipeline (scan_file),
+    the same entry point `detect-secrets-hook` uses - not just the plugin's
+    own analyze_string/analyze_line in isolation."""
+    target = tmp_path / "settings.py"
+    target.write_text(content)
+
+    # detect-secrets caches the custom-plugin class mapping (keyed by
+    # module contents, not by config) across `transient_settings` calls, so
+    # a different test file configuring a different custom plugin earlier
+    # in the run can leave a stale mapping. Not an issue for the real
+    # pre-commit hook (single process, all plugins loaded together once).
+    get_mapping_from_secret_type_to_class.cache_clear()
+
+    with transient_settings(
+        {
+            "plugins_used": [
+                {"name": "BroadKeywordDetector", "path": f"file://{_PLUGIN_FILE}"}
+            ]
+        }
+    ):
+        return list(scan_file(str(target)))
 
 
 # --- Patterns that must be caught ---
@@ -127,79 +141,50 @@ def test_secret_type(detector):
     assert detector.secret_type == "Broad Secret Keyword"  # pragma: allowlist secret
 
 
-# --- Multi-line detection ---
-
-
-def test_detects_triple_quoted_multiline(detector):
-    content = f'KEY = """\n{FAKE_SECRET}\n"""'  # pragma: allowlist secret
-    results = _caught_in_file(detector, content)
-    assert len(results) == 1
-    assert results[0].secret_value == FAKE_SECRET  # pragma: allowlist secret
-    assert results[0].type == detector.secret_type  # pragma: allowlist secret
-
-
-def test_detects_parenthesized_multiline(detector):
-    content = f'TOKEN = (\n    "{FAKE_SECRET}"\n)'  # pragma: allowlist secret
-    results = _caught_in_file(detector, content)
-    assert len(results) == 1
-    assert results[0].secret_value == FAKE_SECRET  # pragma: allowlist secret
-
-
-def test_no_duplicate_for_single_line(detector):
-    content = f'KEY = "{FAKE_SECRET}"'  # pragma: allowlist secret
-    results = _caught_in_file(detector, content)
-    assert len(results) == 1
-
-
-# --- Real pipeline (what pre-commit / CI actually invoke) ---
+# --- Multi-line detection, via the real detect-secrets pipeline ---
 #
 # detect-secrets' scan pipeline (`scan_file`/`scan_diff`) only ever calls a
-# plugin's `analyze_line`/`analyze_string`; it never calls `analyze_file`.
-# `_caught_in_file` above calls `analyze_file` directly, so it doesn't prove
-# the multi-line detection actually runs during a real scan. These tests
-# go through `detect_secrets.core.scan.scan_file`, the same entry point
-# `detect-secrets-hook` uses, to check that.
+# plugin's `analyze_line`, one physical line at a time. There is no "whole
+# file" hook a plugin can implement, so multi-line detection has to work
+# through the `context` (CodeSnippet) that `analyze_line` optionally
+# receives - see BroadKeywordDetector.analyze_line. These tests go through
+# `detect_secrets.core.scan.scan_file`, the same entry point
+# `detect-secrets-hook` uses, rather than calling plugin internals directly,
+# so they actually prove secrets are caught in a real scan/commit.
 
 
-def test_triple_quoted_multiline_secret_caught_by_real_scan(tmp_path):
-    target = tmp_path / "settings.py"
-    target.write_text(f'KEY = """\n{FAKE_SECRET}\n"""\n')  # pragma: allowlist secret
-
-    with transient_settings(
-        {
-            "plugins_used": [
-                {"name": "BroadKeywordDetector", "path": f"file://{_PLUGIN_FILE}"}
-            ]
-        }
-    ):
-        results = list(scan_file(str(target)))
-
-    assert results, (
-        "BroadKeywordDetector.analyze_file() detects triple-quoted multi-line secrets, "
-        "but detect-secrets never calls analyze_file() during a real scan — only "
-        "analyze_line()/analyze_string(). This secret is silently missed by "
-        "`detect-secrets-hook` (the command pre-commit/CI actually run)."
-    )
-
-
-def test_parenthesized_multiline_secret_caught_by_real_scan(tmp_path):
-    target = tmp_path / "settings.py"
-    target.write_text(
-        f'TOKEN = (\n    "{FAKE_SECRET}"\n)\n'
+def test_detects_triple_quoted_multiline(tmp_path):
+    content = f'KEY = """\n{FAKE_SECRET}\n"""\n'  # pragma: allowlist secret
+    results = _scan(tmp_path, content)
+    assert len(results) == 1
+    assert results[0].secret_value == FAKE_SECRET  # pragma: allowlist secret
+    assert (
+        results[0].type == BroadKeywordDetector.secret_type
     )  # pragma: allowlist secret
 
-    with transient_settings(
-        {
-            "plugins_used": [
-                {"name": "BroadKeywordDetector", "path": f"file://{_PLUGIN_FILE}"}
-            ]
-        }
-    ):
-        results = list(scan_file(str(target)))
 
-    assert results, (
-        "BroadKeywordDetector.analyze_file() detects parenthesized multi-line secrets, "
-        "but detect-secrets never calls analyze_file() during a real scan — only "
-        "analyze_line()/analyze_string(). This secret is silently missed by "
-        "`detect-secrets-hook` (the command pre-commit/CI actually run)."
+def test_detects_parenthesized_multiline(tmp_path):
+    content = f'TOKEN = (\n    "{FAKE_SECRET}"\n)\n'  # pragma: allowlist secret
+    results = _scan(tmp_path, content)
+    assert len(results) == 1
+    assert results[0].secret_value == FAKE_SECRET  # pragma: allowlist secret
+
+
+def test_no_duplicate_for_single_line(tmp_path):
+    content = f'KEY = "{FAKE_SECRET}"\n'  # pragma: allowlist secret
+    results = _scan(tmp_path, content)
+    assert len(results) == 1
+
+
+def test_no_duplicate_across_overlapping_context_windows(tmp_path):
+    # Two multi-line secrets close enough together to fall in each other's
+    # context window - each must be reported exactly once, not once per
+    # line it overlaps with.
+    content = (
+        f'KEY = """\n{FAKE_SECRET}\n"""\n'  # pragma: allowlist secret
+        f'TOKEN = (\n    "{FAKE_SECRET_2}"\n)\n'  # pragma: allowlist secret
     )
+    results = _scan(tmp_path, content)
+    secret_values = {r.secret_value for r in results}
+    assert secret_values == {FAKE_SECRET, FAKE_SECRET_2}  # pragma: allowlist secret
+    assert len(results) == 2

--- a/website/tests/test_broad_keyword_detector.py
+++ b/website/tests/test_broad_keyword_detector.py
@@ -1,11 +1,18 @@
 import io
+from pathlib import Path
 
 import pytest
+from detect_secrets.core.scan import scan_file
+from detect_secrets.settings import transient_settings
 
 from detect_secrets_plugins.keywords import BroadKeywordDetector
 
 FAKE_SECRET = "hardcoded-secret-value"  # pragma: allowlist secret
 FAKE_SECRET_2 = "another-hardcoded-secret"  # pragma: allowlist secret
+
+_PLUGIN_FILE = (
+    Path(__file__).resolve().parent.parent / "detect_secrets_plugins" / "keywords.py"
+)
 
 
 class _NamedIO(io.StringIO):
@@ -142,3 +149,57 @@ def test_no_duplicate_for_single_line(detector):
     content = f'KEY = "{FAKE_SECRET}"'  # pragma: allowlist secret
     results = _caught_in_file(detector, content)
     assert len(results) == 1
+
+
+# --- Real pipeline (what pre-commit / CI actually invoke) ---
+#
+# detect-secrets' scan pipeline (`scan_file`/`scan_diff`) only ever calls a
+# plugin's `analyze_line`/`analyze_string`; it never calls `analyze_file`.
+# `_caught_in_file` above calls `analyze_file` directly, so it doesn't prove
+# the multi-line detection actually runs during a real scan. These tests
+# go through `detect_secrets.core.scan.scan_file`, the same entry point
+# `detect-secrets-hook` uses, to check that.
+
+
+def test_triple_quoted_multiline_secret_caught_by_real_scan(tmp_path):
+    target = tmp_path / "settings.py"
+    target.write_text(f'KEY = """\n{FAKE_SECRET}\n"""\n')  # pragma: allowlist secret
+
+    with transient_settings(
+        {
+            "plugins_used": [
+                {"name": "BroadKeywordDetector", "path": f"file://{_PLUGIN_FILE}"}
+            ]
+        }
+    ):
+        results = list(scan_file(str(target)))
+
+    assert results, (
+        "BroadKeywordDetector.analyze_file() detects triple-quoted multi-line secrets, "
+        "but detect-secrets never calls analyze_file() during a real scan — only "
+        "analyze_line()/analyze_string(). This secret is silently missed by "
+        "`detect-secrets-hook` (the command pre-commit/CI actually run)."
+    )
+
+
+def test_parenthesized_multiline_secret_caught_by_real_scan(tmp_path):
+    target = tmp_path / "settings.py"
+    target.write_text(
+        f'TOKEN = (\n    "{FAKE_SECRET}"\n)\n'
+    )  # pragma: allowlist secret
+
+    with transient_settings(
+        {
+            "plugins_used": [
+                {"name": "BroadKeywordDetector", "path": f"file://{_PLUGIN_FILE}"}
+            ]
+        }
+    ):
+        results = list(scan_file(str(target)))
+
+    assert results, (
+        "BroadKeywordDetector.analyze_file() detects parenthesized multi-line secrets, "
+        "but detect-secrets never calls analyze_file() during a real scan — only "
+        "analyze_line()/analyze_string(). This secret is silently missed by "
+        "`detect-secrets-hook` (the command pre-commit/CI actually run)."
+    )

--- a/website/tests/test_detect_secrets_plugin.py
+++ b/website/tests/test_detect_secrets_plugin.py
@@ -1,14 +1,17 @@
-import io
+from pathlib import Path
 
 import pytest
+from detect_secrets.core.plugins.util import get_mapping_from_secret_type_to_class
+from detect_secrets.core.scan import scan_file
+from detect_secrets.settings import transient_settings
 
 from detect_secrets_plugins.wagtail_transfer import WagtailTransferSecretKeyDetector
 
-
-class _NamedIO(io.StringIO):
-    """StringIO with a name attribute so analyze_file can reference the filename."""
-
-    name = "<test>"
+_PLUGIN_FILE = (
+    Path(__file__).resolve().parent.parent
+    / "detect_secrets_plugins"
+    / "wagtail_transfer.py"
+)
 
 
 @pytest.fixture
@@ -20,8 +23,31 @@ def _secrets(detector, line):
     return list(detector.analyze_string(line))
 
 
-def _secrets_in_file(detector, content):
-    return list(detector.analyze_file(_NamedIO(content)))
+def _scan(tmp_path, content):
+    """Scan `content` through the real detect-secrets pipeline (scan_file),
+    the same entry point `detect-secrets-hook` uses - not just the plugin's
+    own analyze_string/analyze_line in isolation."""
+    target = tmp_path / "settings.py"
+    target.write_text(content)
+
+    # detect-secrets caches the custom-plugin class mapping (keyed by
+    # module contents, not by config) across `transient_settings` calls, so
+    # a different test file configuring a different custom plugin earlier
+    # in the run can leave a stale mapping. Not an issue for the real
+    # pre-commit hook (single process, all plugins loaded together once).
+    get_mapping_from_secret_type_to_class.cache_clear()
+
+    with transient_settings(
+        {
+            "plugins_used": [
+                {
+                    "name": "WagtailTransferSecretKeyDetector",
+                    "path": f"file://{_PLUGIN_FILE}",
+                }
+            ]
+        }
+    ):
+        return list(scan_file(str(target)))
 
 
 def test_detects_double_quoted_secret(detector):
@@ -82,20 +108,29 @@ def test_secret_type(detector):
     )
 
 
-# --- Multi-line detection ---
+# --- Multi-line detection, via the real detect-secrets pipeline ---
+#
+# detect-secrets' scan pipeline (`scan_file`/`scan_diff`) only ever calls a
+# plugin's `analyze_line`, one physical line at a time. There is no "whole
+# file" hook a plugin can implement, so multi-line detection has to work
+# through the `context` (CodeSnippet) that `analyze_line` optionally
+# receives - see WagtailTransferSecretKeyDetector.analyze_line. These tests
+# go through `detect_secrets.core.scan.scan_file`, the same entry point
+# `detect-secrets-hook` uses, rather than calling plugin internals directly,
+# so they actually prove the secret is caught in a real scan/commit.
 
 
-def test_detects_triple_quoted_multiline(detector):
-    content = 'WAGTAILTRANSFER_SECRET_KEY = """\nmy-super-secret-key\n"""'  # pragma: allowlist secret
-    results = _secrets_in_file(detector, content)
+def test_detects_triple_quoted_multiline(tmp_path):
+    content = 'WAGTAILTRANSFER_SECRET_KEY = """\nmy-super-secret-key\n"""\n'  # pragma: allowlist secret
+    results = _scan(tmp_path, content)
     assert len(results) == 1
     assert results[0].secret_value == "my-super-secret-key"  # pragma: allowlist secret
-    assert results[0].type == detector.secret_type  # pragma: allowlist secret
+    assert (
+        results[0].type == WagtailTransferSecretKeyDetector.secret_type
+    )  # pragma: allowlist secret
 
 
-def test_no_duplicate_for_single_line(detector):
-    content = (
-        'WAGTAILTRANSFER_SECRET_KEY = "my-super-secret-key"'  # pragma: allowlist secret
-    )
-    results = _secrets_in_file(detector, content)
+def test_no_duplicate_for_single_line(tmp_path):
+    content = 'WAGTAILTRANSFER_SECRET_KEY = "my-super-secret-key"\n'  # pragma: allowlist secret
+    results = _scan(tmp_path, content)
     assert len(results) == 1


### PR DESCRIPTION
## Summary

While reviewing #742, we flagged that only one secret would be detected if two occurred on a single line - that's since been fixed (`finditer` instead of `search`). Digging further while re-verifying that fix turned up a second, unrelated issue in the same plugins' multi-line detection:

- `analyze_file()` is dead code. detect-secrets' scan pipeline (`scan_file`/`scan_diff`) only ever calls a plugin's `analyze_line`/`analyze_string`, one physical line at a time - it never calls `analyze_file()`. The multi-line tests in #742 call `detector.analyze_file(...)` directly, which passes, but doesn't reflect what actually runs during a real scan/commit.
- Verified with the real `detect-secrets-hook` CLI (not just the plugin API): a secret split across a triple-quoted string or parenthesized concatenation is silently missed, while the identical secret on one line is correctly blocked.

This PR is opened against `WAG-1261-detect-secrets` rather than `main` so @grebtaxcourt can decide whether to fold it in as-is or take a different approach - happy to close/rework if there's a preference.

## What changed

- Both plugins now override `analyze_line()` to search the `context` (`CodeSnippet`) window that `analyze_line` optionally receives - a few lines before/after the current one - reporting a match only on the call for the line it starts on, so a match isn't reported once per overlapping line.
- The fix is duplicated across `keywords.py` and `wagtail_transfer.py` rather than shared via a common module: detect-secrets loads each `--plugin <file>` in isolation via `importlib.util.spec_from_file_location`, without adding that file's directory to `sys.path`. A cross-file import between the two plugins only worked by accident under pytest (which happens to put `website/` on `sys.path`) and broke the real `detect-secrets-hook` invocation - worth flagging since it's an easy trap for future plugin changes here.
- Existing multi-line tests now scan through `detect_secrets.core.scan.scan_file` (what `detect-secrets-hook` actually calls) instead of calling `analyze_file()` directly, so a regression here can't hide behind a passing test again.

## Test plan

- [x] `pytest website/tests/test_broad_keyword_detector.py website/tests/test_detect_secrets_plugin.py` - 29 passed
- [x] `ruff check` / `ruff format --check` - clean
- [x] `mypy` - no new errors (one pre-existing, unrelated `analyze_string` signature warning from #742 remains)
- [x] Verified via the actual `detect-secrets-hook` CLI (not just pytest):
  - Triple-quoted secret → blocked
  - Parenthesized-concatenation secret → blocked
  - Two secrets on one line → both blocked
  - Normal single-line secret → still blocked
  - Clean file with no secrets → still passes