### PR TITLE
Fix make start-tunnel for SSO auth and broken DB host wiring

### DIFF
--- a/infra/setup.sh
+++ b/infra/setup.sh
@@ -3,8 +3,6 @@
 source ./helpers.sh
 
 required_env_vars=(
-  "AWS_SECRET_ACCESS_KEY"
-  "AWS_ACCESS_KEY_ID"
   "ENVIRONMENT"
 )
 check_env_vars "${required_env_vars[@]}"

--- a/infra/ssh-tunnel.sh
+++ b/infra/ssh-tunnel.sh
@@ -4,11 +4,15 @@ source ./setup.sh
 
 terraform init \
     -upgrade \
+    -reconfigure \
     -backend=true \
     -backend-config=bucket="${STATE_BUCKET}" \
     -backend-config=key="${KEY}" \
     -backend-config=dynamodb_table="${LOCK_TABLE}" \
-    -backend-config=region="${REGION}"
+    -backend-config=region="${REGION}" || {
+      echo "ERROR: terraform init failed. Aborting before touching bastion state."
+      exit 1
+    }
 
 echo "Applying targeted update to Bastion Security Group..."
 terraform apply -target=module.app.aws_instance.bastion -target=module.app.aws_security_group.bastion_sg -auto-approve

--- a/infra/ssh-tunnel.sh
+++ b/infra/ssh-tunnel.sh
@@ -2,10 +2,6 @@
 
 source ./setup.sh
 
-source ./setup_zone.sh
-
-./update-deployer-policy.sh
-
 terraform init \
     -upgrade \
     -backend=true \
@@ -14,27 +10,37 @@ terraform init \
     -backend-config=dynamodb_table="${LOCK_TABLE}" \
     -backend-config=region="${REGION}"
 
-terraform refresh
-
 echo "Applying targeted update to Bastion Security Group..."
 terraform apply -target=module.app.aws_instance.bastion -target=module.app.aws_security_group.bastion_sg -auto-approve
 
 echo "Bastion Security Group update applied."
 
 BASTION_HOST_IP=$(terraform output -raw bastion_public_ip)
+DATABASE_HOSTNAME=$(terraform output -raw database_endpoint)
 
 mkdir -p .ssh
 echo "${BASTION_PRIVATE_KEY}" | base64 --decode > .ssh/id_rsa
 chmod 600 .ssh/id_rsa
 echo "Bastion private key configured."
 
-ssh-keyscan -H ${BASTION_HOST_IP} > .ssh/known_hosts || { echo "ERROR: ssh-keyscan failed for ${BASTION_HOST_IP}"; exit 1; }
-echo "Host key scanned and added."
+echo "Waiting for bastion host to accept SSH connections..."
+for i in $(seq 1 20); do
+  if ssh-keyscan -H ${BASTION_HOST_IP} > .ssh/known_hosts 2>/dev/null && [ -s .ssh/known_hosts ]; then
+    echo "Host key scanned and added."
+    break
+  fi
+  sleep 5
+done
+
+if [ ! -s .ssh/known_hosts ]; then
+  echo "ERROR: ssh-keyscan failed for ${BASTION_HOST_IP} after waiting for boot"
+  exit 1
+fi
 
 echo "SSH tunnel opened in background. Connect in localhost:5432 ..."
 
 ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=.ssh/known_hosts \
-    -L 5432:${DATABASE_HOSTNAME}:5432 \
+    -L 5432:${DATABASE_HOSTNAME} \
     -N -q -i .ssh/id_rsa ubuntu@${BASTION_HOST_IP} || {
       echo "ERROR: SSH tunnel command failed or was interrupted."
       exit 1;

--- a/infra/ssh-tunnel.sh
+++ b/infra/ssh-tunnel.sh
@@ -16,7 +16,16 @@ terraform apply -target=module.app.aws_instance.bastion -target=module.app.aws_s
 echo "Bastion Security Group update applied."
 
 BASTION_HOST_IP=$(terraform output -raw bastion_public_ip)
+if [ -z "${BASTION_HOST_IP}" ]; then
+  echo "ERROR: terraform output 'bastion_public_ip' is empty. Check that terraform state is initialized."
+  exit 1
+fi
+
 DATABASE_HOSTNAME=$(terraform output -raw database_endpoint)
+if [ -z "${DATABASE_HOSTNAME}" ]; then
+  echo "ERROR: terraform output 'database_endpoint' is empty. Check that terraform state is initialized."
+  exit 1
+fi
 
 mkdir -p .ssh
 echo "${BASTION_PRIVATE_KEY}" | base64 --decode > .ssh/id_rsa
@@ -25,7 +34,7 @@ echo "Bastion private key configured."
 
 echo "Waiting for bastion host to accept SSH connections..."
 for i in $(seq 1 20); do
-  if ssh-keyscan -H ${BASTION_HOST_IP} > .ssh/known_hosts 2>/dev/null && [ -s .ssh/known_hosts ]; then
+  if ssh-keyscan -H "${BASTION_HOST_IP}" > .ssh/known_hosts 2>/dev/null && [ -s .ssh/known_hosts ]; then
     echo "Host key scanned and added."
     break
   fi
@@ -37,11 +46,11 @@ if [ ! -s .ssh/known_hosts ]; then
   exit 1
 fi
 
-echo "SSH tunnel opened in background. Connect in localhost:5432 ..."
+echo "Opening SSH tunnel. Connect in localhost:5432 ..."
 
 ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=.ssh/known_hosts \
-    -L 5432:${DATABASE_HOSTNAME} \
-    -N -q -i .ssh/id_rsa ubuntu@${BASTION_HOST_IP} || {
+    -L "5432:${DATABASE_HOSTNAME}" \
+    -N -q -i .ssh/id_rsa "ubuntu@${BASTION_HOST_IP}" || {
       echo "ERROR: SSH tunnel command failed or was interrupted."
       exit 1;
     }


### PR DESCRIPTION
## Summary
- `setup.sh` required literal `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars, which blocked anyone authenticated via AWS SSO before terraform even ran. `init.sh` already validates working AWS auth via `sts get-caller-identity`, so the extra check was redundant.
- `ssh-tunnel.sh` never set `DATABASE_HOSTNAME` (only CI's workflow env sets it from terraform output) and appended a stray `:5432`, producing a malformed `ssh -L` target.
- Dropped `setup_zone.sh` and `update-deployer-policy.sh` calls, copy-pasted from `deploy.sh`, which mutate Route53/IAM state unrelated to opening a tunnel.
- Dropped the `terraform refresh` step, which was failing outright on an unrelated Docker-daemon check with no error handling to catch it.
- Added a retry loop around `ssh-keyscan`, which ran immediately after instance creation and failed before sshd was up on a fresh boot.

## Test plan
- [x] Ran `make start-tunnel` end-to-end against production with an SSO-authenticated profile (no static AWS keys) and confirmed the tunnel opens successfully on `localhost:5432`.