### PR TITLE
WAG-1331 Updated migration script 0129 to include SQL that should properly run on PSQL databases.

### DIFF
--- a/website/home/migrations/0129_fix_misspelled_accordion_type.py
+++ b/website/home/migrations/0129_fix_misspelled_accordion_type.py
@@ -24,5 +24,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(run_custom_sql_by_backend),
+        migrations.RunPython(run_custom_sql_by_backend, migrations.RunPython.noop),
     ]

--- a/website/home/migrations/0129_fix_misspelled_accordion_type.py
+++ b/website/home/migrations/0129_fix_misspelled_accordion_type.py
@@ -3,13 +3,26 @@
 from django.db import migrations
 
 
+def run_custom_sql_by_backend(apps, schema_editor):
+    # Obtain the current database vendor string
+    vendor = schema_editor.connection.vendor
+
+    with schema_editor.connection.cursor() as cursor:
+        if vendor == "postgresql":
+            cursor.execute(
+                """UPDATE home_enhancedstandardpage set body = replace(body::text, 'accordian', 'accordion')::jsonb;"""
+            )
+        else:
+            cursor.execute(
+                """UPDATE home_enhancedstandardpage set body = replace(body, 'accordian', 'accordion');"""
+            )
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("home", "0128_remove_pressreleasepage_press_release_body"),
     ]
 
     operations = [
-        migrations.RunSQL(
-            sql="""UPDATE home_enhancedstandardpage set body = replace(body, 'accordian', 'accordion');""",
-        ),
+        migrations.RunPython(run_custom_sql_by_backend),
     ]


### PR DESCRIPTION
## Jira Ticket
Please include the Jira issue ID in the correct format.

**Ticket:** WAG-1331

---

## Summary of Changes
Updated migration script 0129 so that it will properly run on PostgreSQL databases

---

## Testing Instructions
Provide clear steps for the reviewer to test this change. Please consider any manual steps.

- Verify that the word "accordion" is spelled correctly throughout the site (e.g., "Accordion Block" is the name of a component that can be selected on an Enhanced Standard Page, any help text of an Accordion Block's fields, etc.)
- Verify that the "Accordion Block" looks and behaves as expected on any page where it is used.